### PR TITLE
21 27 implement student account page backend

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,5 +1,7 @@
 PORT=3001
 CLIENT_URL=http://localhost:5173
+CORS_ORIGINS=http://localhost:5173
+CORS_ALLOW_NO_ORIGIN=true
 API_BASE_URL=http://localhost:3001
 NODE_ENV=development
 SESSION_SECRET=change-me-in-production

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ Backend REST API do projeto gestArtes, desenvolvido para a Escola Entartes.
 
 - Node.js + Express
 - Prisma ORM com SQL Server
-- dotenv, cors, express-session
+- dotenv, cors, express-session, helmet
 - morgan (logs HTTP no console)
 - winston (logs estruturados para ficheiro)
 - express-rate-limit (rate limiting básico)
@@ -32,6 +32,12 @@ npm install
 ```
 
 2. Copiar .env.example para .env e preencher valores.
+
+Variáveis de segurança relevantes:
+
+- `CORS_ORIGINS`: lista separada por vírgula com origins permitidas (fallback para `CLIENT_URL`).
+- `CORS_ALLOW_NO_ORIGIN`: permite requests sem Origin (ex.: curl/Postman).
+- Em produção, é obrigatório configurar pelo menos uma origin em `CORS_ORIGINS` ou `CLIENT_URL`.
 
 3. Executar em desenvolvimento:
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -19,6 +19,7 @@
         "express-rate-limit": "^8.3.2",
         "express-session": "^1.19.0",
         "express-validator": "^7.3.2",
+        "helmet": "^8.1.0",
         "morgan": "^1.10.1",
         "swagger-jsdoc": "^6.2.8",
         "swagger-ui-express": "^5.0.1",
@@ -2341,6 +2342,15 @@
       },
       "engines": {
         "node": ">= 0.4"
+      }
+    },
+    "node_modules/helmet": {
+      "version": "8.1.0",
+      "resolved": "https://registry.npmjs.org/helmet/-/helmet-8.1.0.tgz",
+      "integrity": "sha512-jOiHyAZsmnr8LqoPGmCjYAaiuWwjAPLgY8ZX2XrmHawt99/u1y6RgrZMTeoPfpUbV96HOalYgz1qzkRbw54Pmg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18.0.0"
       }
     },
     "node_modules/hono": {

--- a/package.json
+++ b/package.json
@@ -39,6 +39,7 @@
     "express-rate-limit": "^8.3.2",
     "express-session": "^1.19.0",
     "express-validator": "^7.3.2",
+    "helmet": "^8.1.0",
     "morgan": "^1.10.1",
     "swagger-jsdoc": "^6.2.8",
     "swagger-ui-express": "^5.0.1",

--- a/src/app.js
+++ b/src/app.js
@@ -5,6 +5,7 @@ const express = require('express');
 const session = require('express-session');
 const MSSQLStore = require('connect-mssql-v2');
 const cors = require('cors');
+const helmet = require('helmet');
 const morgan = require('morgan');
 
 const authRoutes = require('./routes/auth.routes');
@@ -21,7 +22,13 @@ const SESSION_TABLE_NAME = 'Sessions';
 const SESSION_AUTO_REMOVE_INTERVAL_MS = 1000 * 60 * 10;
 const SESSION_STORE_RETRIES = 1;
 const SESSION_STORE_RETRY_DELAY_MS = 1000;
+const CSP_NONCE_BYTE_LENGTH = 16;
 const IS_PRODUCTION = process.env.NODE_ENV === 'production';
+const CORS_ALLOW_NO_ORIGIN = parseBoolean(
+  process.env.CORS_ALLOW_NO_ORIGIN,
+  true
+);
+const CORS_ORIGINS = buildCorsAllowList();
 const SESSION_CROSS_SITE = parseBoolean(
   process.env.SESSION_COOKIE_CROSS_SITE,
   false
@@ -39,6 +46,16 @@ if (IS_PRODUCTION && !HAS_SESSION_SECRET) {
 
 if (!HAS_SESSION_SECRET) {
   logger.warn('SESSION_SECRET not set; using an ephemeral development secret');
+}
+
+if (IS_PRODUCTION && CORS_ORIGINS.length === 0) {
+  throw new Error(
+    'At least one CORS origin is required in production (CORS_ORIGINS or CLIENT_URL)'
+  );
+}
+
+if (!IS_PRODUCTION && CORS_ORIGINS.length === 0) {
+  logger.warn('No CORS origins configured; allowing all origins in non-production');
 }
 
 function parseBoolean(value, fallback) {
@@ -62,6 +79,85 @@ function parseBoolean(value, fallback) {
 
   return fallback;
 }
+
+function parseCsv(value) {
+  if (value === undefined || value === null || value === '') {
+    return [];
+  }
+
+  return String(value)
+    .split(',')
+    .map((entry) => entry.trim())
+    .filter(Boolean);
+}
+
+function buildCorsAllowList() {
+  return Array.from(
+    new Set([...parseCsv(process.env.CORS_ORIGINS), ...parseCsv(process.env.CLIENT_URL)])
+  );
+}
+
+function createCorsOriginValidator(allowedOrigins) {
+  const allowList = new Set(allowedOrigins);
+
+  return (origin, callback) => {
+    if (!origin) {
+      return callback(null, CORS_ALLOW_NO_ORIGIN);
+    }
+
+    if (allowList.size === 0 || allowList.has(origin)) {
+      return callback(null, true);
+    }
+
+    return callback(null, false);
+  };
+}
+
+function buildCspNonceSource(req, res) {
+  return `'nonce-${res.locals.cspNonce}'`;
+}
+
+function attachCspNonce(req, res, next) {
+  res.locals.cspNonce = crypto
+    .randomBytes(CSP_NONCE_BYTE_LENGTH)
+    .toString('hex');
+  next();
+}
+
+const apiCspMiddleware = helmet.contentSecurityPolicy({
+  useDefaults: true,
+  directives: {
+    defaultSrc: ["'self'"],
+    baseUri: ["'self'"],
+    objectSrc: ["'none'"],
+    frameAncestors: ["'none'"],
+    scriptSrc: ["'self'"],
+    styleSrc: ["'self'"],
+    imgSrc: ["'self'", 'data:'],
+    connectSrc: ["'self'"],
+    fontSrc: ["'self'", 'data:'],
+    formAction: ["'self'"],
+    upgradeInsecureRequests: IS_PRODUCTION ? [] : null,
+  },
+});
+
+const docsCspMiddleware = helmet.contentSecurityPolicy({
+  useDefaults: true,
+  directives: {
+    defaultSrc: ["'self'"],
+    baseUri: ["'self'"],
+    objectSrc: ["'none'"],
+    frameAncestors: ["'none'"],
+    scriptSrc: ["'self'", buildCspNonceSource],
+    styleSrc: ["'self'", buildCspNonceSource],
+    styleSrcAttr: ["'none'"],
+    imgSrc: ["'self'", 'data:'],
+    connectSrc: ["'self'"],
+    fontSrc: ["'self'", 'data:'],
+    formAction: ["'self'"],
+    upgradeInsecureRequests: IS_PRODUCTION ? [] : null,
+  },
+});
 
 function sanitizeConnectionString(value) {
   if (!value) {
@@ -179,7 +275,28 @@ sessionStore.on('sessionError', (error, method) => {
   logger.error(`Session store method error (${method}): ${error.message}`);
 });
 
-app.use(cors({ origin: process.env.CLIENT_URL, credentials: true }));
+app.use(
+  cors({
+    origin: createCorsOriginValidator(CORS_ORIGINS),
+    credentials: true,
+    optionsSuccessStatus: 204,
+  })
+);
+app.use(
+  helmet({
+    contentSecurityPolicy: false,
+    frameguard: { action: 'deny' },
+    referrerPolicy: { policy: 'no-referrer' },
+  })
+);
+app.use(attachCspNonce);
+app.use((req, res, next) => {
+  if (req.path.startsWith('/docs')) {
+    return docsCspMiddleware(req, res, next);
+  }
+
+  return apiCspMiddleware(req, res, next);
+});
 app.use(express.json());
 app.use(morgan('dev'));
 if (parseBoolean(process.env.TRUST_PROXY, false)) {

--- a/src/app.js
+++ b/src/app.js
@@ -9,6 +9,7 @@ const helmet = require('helmet');
 const morgan = require('morgan');
 
 const authRoutes = require('./routes/auth.routes');
+const studentRoutes = require('./routes/student.routes');
 const apiRateLimiter = require('./middlewares/rateLimit.middleware');
 const errorHandler = require('./middlewares/error.middleware');
 const { setupSwagger } = require('./config/swagger');
@@ -323,6 +324,7 @@ app.use(apiRateLimiter);
 
 // Routes
 app.use('/auth', authRoutes);
+app.use('/student', studentRoutes);
 
 app.get('/health', (req, res) => res.json({ status: 'ok' }));
 

--- a/src/config/swagger.js
+++ b/src/config/swagger.js
@@ -30,7 +30,7 @@ function injectCspNonceInSwaggerHtml(html, nonce) {
 
   return html
     .replace(
-      /<svg([^>]*?)\sstyle="position:absolute;width:0;height:0"/,
+      /<svg([^>]*?)\sstyle="position:absolute;width:0;height:0"/g,
       '<svg$1 class="swagger-hidden-svg"'
     )
     .replace(/<script(?![^>]*\snonce=)/g, `<script nonce="${nonce}"`)
@@ -69,6 +69,7 @@ function setupSwagger(app) {
 }
 
 module.exports = {
+  injectCspNonceInSwaggerHtml,
   setupSwagger,
   swaggerSpec,
 };

--- a/src/config/swagger.js
+++ b/src/config/swagger.js
@@ -21,8 +21,47 @@ const swaggerSpec = swaggerJsdoc({
   apis: [],
 });
 
+const swaggerHiddenSvgCss = '.swagger-hidden-svg { position: absolute; width: 0; height: 0; }';
+
+function injectCspNonceInSwaggerHtml(html, nonce) {
+  if (!nonce) {
+    return html;
+  }
+
+  return html
+    .replace(
+      /<svg([^>]*?)\sstyle="position:absolute;width:0;height:0"/,
+      '<svg$1 class="swagger-hidden-svg"'
+    )
+    .replace(/<script(?![^>]*\snonce=)/g, `<script nonce="${nonce}"`)
+    .replace(/<style(?![^>]*\snonce=)/g, `<style nonce="${nonce}"`);
+}
+
 function setupSwagger(app) {
-  app.use('/docs', swaggerUi.serve, swaggerUi.setup(swaggerSpec));
+  const docsHandler = (req, res) => {
+    const html = swaggerUi.generateHTML(swaggerSpec, {
+      customCss: swaggerHiddenSvgCss,
+    });
+    const htmlWithNonce = injectCspNonceInSwaggerHtml(
+      html,
+      res.locals.cspNonce
+    );
+
+    res.type('html');
+    res.send(htmlWithNonce);
+  };
+
+  app.use((req, res, next) => {
+    if (req.path === '/docs') {
+      return res.redirect(308, '/docs/');
+    }
+
+    return next();
+  });
+
+  app.use('/docs', swaggerUi.serve);
+  app.get('/docs/', docsHandler);
+
   app.get('/docs.json', (req, res) => {
     res.setHeader('Content-Type', 'application/json');
     res.send(swaggerSpec);

--- a/src/controllers/student.controller.js
+++ b/src/controllers/student.controller.js
@@ -63,7 +63,7 @@ async function getProfile(req, res, next) {
       return;
     }
 
-    if (role && role !== 'student') {
+    if (role !== 'student') {
       res.status(403).json({ error: 'Forbidden' });
       return;
     }

--- a/src/controllers/student.controller.js
+++ b/src/controllers/student.controller.js
@@ -1,0 +1,244 @@
+const prisma = require('../config/prisma');
+
+const ATTENDED_STATUS_KEYWORDS = [
+  'attended',
+  'present',
+  'presente',
+  'compareceu',
+  'assistiu',
+];
+const NOT_ATTENDED_STATUS_KEYWORDS = [
+  'absent',
+  'faltou',
+  'missed',
+  'cancel',
+  'nao compareceu',
+  'no show',
+];
+
+function toInteger(value) {
+  if (typeof value === 'bigint') {
+    return Number(value);
+  }
+
+  const parsed = Number(value);
+  return Number.isFinite(parsed) ? parsed : 0;
+}
+
+function normalizeStatusName(value) {
+  return String(value || '')
+    .trim()
+    .toLowerCase()
+    .normalize('NFD')
+    .replace(/[\u0300-\u036f]/g, '');
+}
+
+function isAttendedStatus(statusName) {
+  const normalized = normalizeStatusName(statusName);
+
+  if (!normalized) {
+    return false;
+  }
+
+  if (NOT_ATTENDED_STATUS_KEYWORDS.some((keyword) => normalized.includes(keyword))) {
+    return false;
+  }
+
+  return ATTENDED_STATUS_KEYWORDS.some((keyword) => normalized.includes(keyword));
+}
+
+function toStudentCode(studentAccountId) {
+  return `ST-${String(studentAccountId).padStart(4, '0')}`;
+}
+
+async function getProfile(req, res, next) {
+  try {
+    const userId = Number(req.session?.userId);
+    const role = String(req.session?.role || '')
+      .trim()
+      .toLowerCase();
+
+    if (!Number.isInteger(userId) || userId <= 0) {
+      res.status(401).json({ error: 'Not authenticated' });
+      return;
+    }
+
+    if (role && role !== 'student') {
+      res.status(403).json({ error: 'Forbidden' });
+      return;
+    }
+
+    const profileRows = await prisma.$queryRaw`
+      SELECT
+        u.UserID AS userId,
+        u.AuthUID AS authUid,
+        u.FirstName AS firstName,
+        u.LastName AS lastName,
+        u.Email AS email,
+        u.PhoneNumber AS phoneNumber,
+        u.Photo AS photoUrl,
+        u.CreatedAt AS accountCreatedAt,
+        u.UpdatedAt AS accountUpdatedAt,
+        sa.StudentAccountID AS studentAccountId,
+        sa.BirthDate AS birthDate,
+        sa.GuardianName AS guardianName,
+        sa.GuardianPhone AS guardianPhone
+      FROM [User] AS u
+      INNER JOIN [StudentAccount] AS sa ON sa.UserID = u.UserID
+      WHERE u.UserID = ${userId}
+        AND u.IsActive = 1
+        AND u.DeletedAt IS NULL
+    `;
+
+    const profileRow = profileRows[0];
+
+    if (!profileRow) {
+      res.status(404).json({ error: 'Student account not found' });
+      return;
+    }
+
+    const studentAccountId = toInteger(profileRow.studentAccountId);
+
+    const [
+      sessionStatsRows,
+      attendanceRows,
+      nextSessionsRows,
+      modalityRows,
+      totalJoinRequests,
+      totalInventoryRentals,
+      totalMarketplacePurchases,
+    ] = await Promise.all([
+      prisma.$queryRaw`
+        SELECT
+          COUNT(1) AS totalSessionsEnrolled,
+          SUM(CASE WHEN cs.StartTime >= SYSUTCDATETIME() THEN 1 ELSE 0 END) AS upcomingSessions,
+          SUM(CASE WHEN cs.EndTime < SYSUTCDATETIME() THEN 1 ELSE 0 END) AS completedSessions
+        FROM [SessionStudent] AS ss
+        INNER JOIN [CoachingSession] AS cs ON cs.SessionID = ss.SessionID
+        WHERE ss.StudentAccountID = ${studentAccountId}
+      `,
+      prisma.$queryRaw`
+        SELECT
+          ast.StatusName AS statusName,
+          COUNT(1) AS total
+        FROM [SessionStudent] AS ss
+        INNER JOIN [AttendanceStatus] AS ast ON ast.AttendanceStatusID = ss.AttendanceStatusID
+        WHERE ss.StudentAccountID = ${studentAccountId}
+        GROUP BY ast.StatusName
+        ORDER BY ast.StatusName ASC
+      `,
+      prisma.$queryRaw`
+        SELECT TOP (5)
+          cs.SessionID AS sessionId,
+          cs.StartTime AS startTime,
+          cs.EndTime AS endTime,
+          m.ModalityName AS modalityName,
+          st.StudioName AS studioName,
+          sst.StatusName AS sessionStatus
+        FROM [SessionStudent] AS ss
+        INNER JOIN [CoachingSession] AS cs ON cs.SessionID = ss.SessionID
+        INNER JOIN [Modality] AS m ON m.ModalityID = cs.ModalityID
+        INNER JOIN [Studio] AS st ON st.StudioID = cs.StudioID
+        INNER JOIN [SessionStatus] AS sst ON sst.StatusID = cs.StatusID
+        WHERE ss.StudentAccountID = ${studentAccountId}
+          AND cs.StartTime >= SYSUTCDATETIME()
+        ORDER BY cs.StartTime ASC
+      `,
+      prisma.$queryRaw`
+        SELECT
+          m.ModalityName AS modalityName,
+          COUNT(1) AS sessions
+        FROM [SessionStudent] AS ss
+        INNER JOIN [CoachingSession] AS cs ON cs.SessionID = ss.SessionID
+        INNER JOIN [Modality] AS m ON m.ModalityID = cs.ModalityID
+        WHERE ss.StudentAccountID = ${studentAccountId}
+        GROUP BY m.ModalityName
+        ORDER BY COUNT(1) DESC, m.ModalityName ASC
+      `,
+      prisma.coachingJoinRequest.count({
+        where: {
+          StudentAccountID: studentAccountId,
+        },
+      }),
+      prisma.inventoryTransaction.count({
+        where: {
+          RenterID: userId,
+        },
+      }),
+      prisma.marketplaceTransaction.count({
+        where: {
+          BuyerID: userId,
+        },
+      }),
+    ]);
+
+    const sessionStats = sessionStatsRows[0] || {};
+
+    const attendanceByStatus = attendanceRows.map((row) => ({
+      statusName: row.statusName,
+      total: toInteger(row.total),
+    }));
+
+    const totalSessionsAttended = attendanceByStatus.reduce((acc, item) => {
+      if (!isAttendedStatus(item.statusName)) {
+        return acc;
+      }
+
+      return acc + item.total;
+    }, 0);
+
+    const modalityDistribution = modalityRows.map((row) => ({
+      modalityName: row.modalityName,
+      sessions: toInteger(row.sessions),
+    }));
+
+    const nextSessions = nextSessionsRows.map((row) => ({
+      sessionId: toInteger(row.sessionId),
+      startTime: row.startTime,
+      endTime: row.endTime,
+      modalityName: row.modalityName,
+      studioName: row.studioName,
+      status: row.sessionStatus,
+    }));
+
+    res.json({
+      profile: {
+        userId: toInteger(profileRow.userId),
+        authUid: profileRow.authUid,
+        studentAccountId,
+        studentCode: toStudentCode(studentAccountId),
+        firstName: profileRow.firstName,
+        lastName: profileRow.lastName,
+        email: profileRow.email,
+        phoneNumber: profileRow.phoneNumber,
+        photoUrl: profileRow.photoUrl,
+        birthDate: profileRow.birthDate,
+        guardianName: profileRow.guardianName,
+        guardianPhone: profileRow.guardianPhone,
+        accountCreatedAt: profileRow.accountCreatedAt,
+        accountUpdatedAt: profileRow.accountUpdatedAt,
+      },
+      trainingPlan: {
+        name: modalityDistribution[0]?.modalityName || null,
+        modalityDistribution,
+        nextSessions,
+      },
+      statistics: {
+        totalSessionsEnrolled: toInteger(sessionStats.totalSessionsEnrolled),
+        totalSessionsAttended,
+        upcomingSessions: toInteger(sessionStats.upcomingSessions),
+        completedSessions: toInteger(sessionStats.completedSessions),
+        totalJoinRequests,
+        totalInventoryRentals,
+        totalMarketplacePurchases,
+        attendanceByStatus,
+      },
+    });
+  } catch (error) {
+    next(error);
+  }
+}
+
+module.exports = {
+  getProfile,
+};

--- a/src/routes/student.routes.js
+++ b/src/routes/student.routes.js
@@ -1,0 +1,9 @@
+const express = require('express');
+const { requireAuth } = require('../middlewares/auth.middleware');
+const studentController = require('../controllers/student.controller');
+
+const router = express.Router();
+
+router.get('/profile', requireAuth, studentController.getProfile);
+
+module.exports = router;

--- a/test/integration/security.integration.test.js
+++ b/test/integration/security.integration.test.js
@@ -1,0 +1,165 @@
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const http = require('node:http');
+const Module = require('node:module');
+
+process.env.NODE_ENV = process.env.NODE_ENV || 'test';
+process.env.CLIENT_URL = process.env.CLIENT_URL || 'http://localhost:5173';
+process.env.CORS_ORIGINS = process.env.CORS_ORIGINS || 'http://localhost:5173';
+process.env.CORS_ALLOW_NO_ORIGIN = process.env.CORS_ALLOW_NO_ORIGIN || 'true';
+process.env.SESSION_SECRET = process.env.SESSION_SECRET || 'test-secret';
+process.env.DATABASE_URL =
+  process.env.DATABASE_URL ||
+  'sqlserver://localhost;database=gestArtes_test;user=test;password=test;encrypt=true;trustServerCertificate=true;';
+
+class FakeMssqlStore {
+  constructor() {}
+
+  on() {
+    return this;
+  }
+
+  get(_sessionId, callback) {
+    if (callback) {
+      callback(null, null);
+    }
+  }
+
+  set(_sessionId, _session, callback) {
+    if (callback) {
+      callback(null);
+    }
+  }
+
+  destroy(_sessionId, callback) {
+    if (callback) {
+      callback(null);
+    }
+  }
+
+  touch(_sessionId, _session, callback) {
+    if (callback) {
+      callback(null);
+    }
+  }
+
+  length(callback) {
+    if (callback) {
+      callback(null, 0);
+    }
+  }
+
+  all(callback) {
+    if (callback) {
+      callback(null, []);
+    }
+  }
+
+  clear(callback) {
+    if (callback) {
+      callback(null);
+    }
+  }
+}
+
+const originalLoad = Module._load;
+Module._load = function patchedLoad(request, parent, isMain) {
+  if (request === 'connect-mssql-v2') {
+    return FakeMssqlStore;
+  }
+
+  return originalLoad.call(this, request, parent, isMain);
+};
+
+const app = require('../../src/app');
+
+Module._load = originalLoad;
+
+let server;
+let baseUrl;
+
+test.before(async () => {
+  server = http.createServer(app);
+
+  await new Promise((resolve) => {
+    server.listen(0, resolve);
+  });
+
+  const address = server.address();
+  baseUrl = `http://127.0.0.1:${address.port}`;
+});
+
+test.after(async () => {
+  if (!server) {
+    return;
+  }
+
+  await new Promise((resolve, reject) => {
+    server.close((error) => {
+      if (error) {
+        reject(error);
+        return;
+      }
+
+      resolve();
+    });
+  });
+});
+
+async function request(path, options = {}) {
+  return fetch(`${baseUrl}${path}`, options);
+}
+
+test('health endpoint exposes security headers and allows the configured origin', async () => {
+  const response = await request('/health', {
+    headers: {
+      Origin: 'http://localhost:5173',
+    },
+  });
+
+  assert.equal(response.status, 200);
+  assert.equal(response.headers.get('access-control-allow-origin'), 'http://localhost:5173');
+  assert.equal(response.headers.get('x-frame-options'), 'DENY');
+  assert.equal(response.headers.get('referrer-policy'), 'no-referrer');
+
+  const csp = response.headers.get('content-security-policy');
+  assert.ok(csp);
+  assert.match(csp, /default-src 'self'/);
+  assert.match(csp, /frame-ancestors 'none'/);
+  assert.doesNotMatch(csp, /unsafe-inline/);
+});
+
+test('health endpoint does not allow unlisted origins', async () => {
+  const response = await request('/health', {
+    headers: {
+      Origin: 'http://evil.example',
+    },
+  });
+
+  assert.equal(response.status, 200);
+  assert.equal(response.headers.get('access-control-allow-origin'), null);
+});
+
+test('docs redirects to trailing slash and serves nonce-hardened HTML', async () => {
+  const redirectResponse = await request('/docs', {
+    redirect: 'manual',
+  });
+
+  assert.equal(redirectResponse.status, 308);
+  assert.equal(redirectResponse.headers.get('location'), '/docs/');
+
+  const docsResponse = await request('/docs/');
+  assert.equal(docsResponse.status, 200);
+
+  const csp = docsResponse.headers.get('content-security-policy');
+  assert.ok(csp);
+  assert.match(csp, /script-src[^;]*'nonce-[^']+'/);
+  assert.match(csp, /style-src[^;]*'nonce-[^']+'/);
+  assert.match(csp, /style-src-attr 'none'/);
+  assert.doesNotMatch(csp, /unsafe-inline/);
+
+  const html = await docsResponse.text();
+  assert.match(html, /class="swagger-hidden-svg"/);
+  assert.doesNotMatch(html, /style="position:absolute;width:0;height:0"/);
+  assert.match(html, /nonce="[^"]+"/);
+});

--- a/test/integration/security.integration.test.js
+++ b/test/integration/security.integration.test.js
@@ -71,9 +71,17 @@ Module._load = function patchedLoad(request, parent, isMain) {
   return originalLoad.call(this, request, parent, isMain);
 };
 
-const app = require('../../src/app');
+let app;
 
-Module._load = originalLoad;
+try {
+  app = require('../../src/app');
+} finally {
+  Module._load = originalLoad;
+}
+
+const {
+  injectCspNonceInSwaggerHtml,
+} = require('../../src/config/swagger');
 
 let server;
 let baseUrl;
@@ -162,4 +170,16 @@ test('docs redirects to trailing slash and serves nonce-hardened HTML', async ()
   assert.match(html, /class="swagger-hidden-svg"/);
   assert.doesNotMatch(html, /style="position:absolute;width:0;height:0"/);
   assert.match(html, /nonce="[^"]+"/);
+});
+
+test('swagger helper rewrites every hidden svg placeholder', () => {
+  const html = [
+    '<svg aria-hidden="true" style="position:absolute;width:0;height:0"></svg>',
+    '<div><svg focusable="false" style="position:absolute;width:0;height:0"></svg></div>',
+  ].join('');
+
+  const rewritten = injectCspNonceInSwaggerHtml(html, 'nonce-123');
+
+  assert.equal((rewritten.match(/class="swagger-hidden-svg"/g) || []).length, 2);
+  assert.doesNotMatch(rewritten, /style="position:absolute;width:0;height:0"/);
 });

--- a/test/integration/security.integration.test.js
+++ b/test/integration/security.integration.test.js
@@ -183,3 +183,24 @@ test('swagger helper rewrites every hidden svg placeholder', () => {
   assert.equal((rewritten.match(/class="swagger-hidden-svg"/g) || []).length, 2);
   assert.doesNotMatch(rewritten, /style="position:absolute;width:0;height:0"/);
 });
+
+test('student profile endpoint requires authentication', async () => {
+  const response = await request('/student/profile');
+
+  assert.equal(response.status, 401);
+
+  const body = await response.json();
+  assert.equal(body.error, 'Not authenticated');
+});
+
+test('student profile has no update endpoints (read-only)', async () => {
+  const putResponse = await request('/student/profile', {
+    method: 'PUT',
+  });
+  const patchResponse = await request('/student/profile', {
+    method: 'PATCH',
+  });
+
+  assert.equal(putResponse.status, 404);
+  assert.equal(patchResponse.status, 404);
+});

--- a/test/unit/student.controller.test.js
+++ b/test/unit/student.controller.test.js
@@ -1,0 +1,74 @@
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const Module = require('node:module');
+
+const fakePrisma = {
+  $queryRaw: async () => {
+    throw new Error('Unexpected database access');
+  },
+  coachingJoinRequest: {
+    count: async () => {
+      throw new Error('Unexpected database access');
+    },
+  },
+  inventoryTransaction: {
+    count: async () => {
+      throw new Error('Unexpected database access');
+    },
+  },
+  marketplaceTransaction: {
+    count: async () => {
+      throw new Error('Unexpected database access');
+    },
+  },
+};
+
+const originalLoad = Module._load;
+Module._load = function patchedLoad(request, parent, isMain) {
+  if (request === '../config/prisma') {
+    return fakePrisma;
+  }
+
+  return originalLoad.call(this, request, parent, isMain);
+};
+
+let getProfile;
+
+try {
+  ({ getProfile } = require('../../src/controllers/student.controller'));
+} finally {
+  Module._load = originalLoad;
+}
+
+function createResponse() {
+  return {
+    statusCode: null,
+    payload: null,
+    status(code) {
+      this.statusCode = code;
+      return this;
+    },
+    json(body) {
+      this.payload = body;
+      return this;
+    },
+  };
+}
+
+test('student profile rejects sessions without a student role', async () => {
+  const req = {
+    session: {
+      userId: 123,
+    },
+  };
+  const res = createResponse();
+  let nextCalled = false;
+
+  await getProfile(req, res, () => {
+    nextCalled = true;
+  });
+
+  assert.equal(res.statusCode, 403);
+  assert.deepEqual(res.payload, { error: 'Forbidden' });
+  assert.equal(nextCalled, false);
+});


### PR DESCRIPTION
## Resumo das alterações

- Adicionado o endpoint read-only `GET /student/profile` para devolver os dados de perfil do aluno.
- Implementado o join entre `User` e `StudentAccount` para compor a resposta do perfil.
- Incluídos dados úteis para a página de conta, como informação pessoal, contacto, plano de formação e estatísticas da conta.
- Criado o controller e a rota dedicados ao módulo de estudante.
- Integrada a nova rota na aplicação principal.
- Mantida a proteção por autenticação e sem qualquer endpoint de edição do perfil.
- Acrescentada cobertura de testes de integração para validar o acesso autenticado e o comportamento read-only.