### PR TITLE
69 be 11 pricing service financial penalties

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,8 @@
   "description": "",
   "main": "src/app.js",
   "scripts": {
-    "test": "node --test test/integration/*.test.js",
+    "test": "node --test test/unit/*.test.js test/integration/*.test.js",
+    "test:unit": "node --test test/unit/*.test.js",
     "test:integration": "cross-env RUN_DB_INTEGRATION_TESTS=true node --test test/integration/*.test.js",
     "dev": "nodemon src/app.js",
     "start": "node src/app.js",

--- a/prisma/migrations/20260422_000001_financial_summary_unique_period/migration.sql
+++ b/prisma/migrations/20260422_000001_financial_summary_unique_period/migration.sql
@@ -1,0 +1,10 @@
+IF NOT EXISTS (
+    SELECT 1
+    FROM sys.indexes
+    WHERE name = 'UQ_FinancialSummary_Period'
+      AND object_id = OBJECT_ID('dbo.FinancialSummary')
+)
+BEGIN
+    CREATE UNIQUE INDEX [UQ_FinancialSummary_Period]
+        ON [dbo].[FinancialSummary] ([PeriodStart], [PeriodEnd]);
+END;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -133,6 +133,8 @@ model FinancialSummary {
   FinancialEntry     FinancialEntry[]
   User               User             @relation(fields: [GeneratedByUserID], references: [UserID], onUpdate: NoAction, map: "FKFinancialS483396")
   AcademicYear       AcademicYear     @relation(fields: [AcademicYearID], references: [AcademicYearID], onUpdate: NoAction, map: "FKFinancialS977589")
+
+  @@unique([PeriodStart, PeriodEnd], map: "UQ_FinancialSummary_Period")
 }
 
 model InventoryItem {

--- a/src/services/pricing.service.js
+++ b/src/services/pricing.service.js
@@ -1,0 +1,119 @@
+const prisma = require('../config/prisma');
+
+const OUTSIDE_HOURS_MULTIPLIER = 1.5; // BR-18
+// TODO BR-18: exact external multiplier not yet documented
+const EXTERNAL_MULTIPLIER = 1.0;
+
+async function calculateFinalPrice(sessionId) {
+  const session = await prisma.coachingSession.findUnique({
+    where: { SessionID: sessionId },
+    include: { SessionPricingRate: true },
+  });
+
+  if (!session) {
+    throw new Error(`Session ${sessionId} not found`);
+  }
+
+  const durationHours = (session.EndTime - session.StartTime) / 3_600_000;
+  let price = Number(session.SessionPricingRate.HourlyRate) * durationHours;
+
+  if (session.IsOutsideStdHours) {
+    price *= OUTSIDE_HOURS_MULTIPLIER;
+  }
+  if (session.IsExternal) {
+    price *= EXTERNAL_MULTIPLIER;
+  }
+
+  return Number(price.toFixed(2));
+}
+
+async function _findOrCreateMonthSummary(tx, userId) {
+  const now = new Date();
+  const periodStart = new Date(now.getFullYear(), now.getMonth(), 1);
+  const periodEnd = new Date(now.getFullYear(), now.getMonth() + 1, 0);
+
+  const existing = await tx.financialSummary.findFirst({
+    where: { PeriodStart: periodStart, PeriodEnd: periodEnd },
+  });
+  if (existing) return existing;
+
+  const activeYear = await tx.academicYear.findFirst({
+    where: { IsActive: true },
+  });
+  if (!activeYear) {
+    throw new Error('No active academic year found');
+  }
+
+  return tx.financialSummary.create({
+    data: {
+      PeriodStart: periodStart,
+      PeriodEnd: periodEnd,
+      GeneratedAt: now,
+      TotalAmount: 0,
+      GeneratedByUserID: userId,
+      IsExported: false,
+      AcademicYearID: activeYear.AcademicYearID,
+    },
+  });
+}
+
+async function applyNoShowPenalty(sessionId, userId) {
+  const finalPrice = await calculateFinalPrice(sessionId);
+
+  return prisma.$transaction(async (tx) => {
+    const entryType = await tx.financialEntryType.findFirst({
+      where: { TypeName: 'NOSHOWPENALTY' },
+    });
+    if (!entryType) throw new Error("FinancialEntryType 'NOSHOWPENALTY' not found");
+
+    const summary = await _findOrCreateMonthSummary(tx, userId);
+
+    return tx.financialEntry.create({
+      data: {
+        SessionID: sessionId,
+        Amount: finalPrice,
+        EntryTypeID: entryType.EntryTypeID,
+        FinancialSummaryID: summary.FinancialSummaryID,
+        CreatedAt: new Date(),
+        IsExported: false,
+      },
+    });
+  });
+}
+
+async function generateFinancialEntryOnFinalization(sessionId, userId) {
+  const finalPrice = await calculateFinalPrice(sessionId);
+
+  return prisma.$transaction(async (tx) => {
+    const entryType = await tx.financialEntryType.findFirst({
+      where: { TypeName: 'SESSION' },
+    });
+    if (!entryType) throw new Error("FinancialEntryType 'SESSION' not found");
+
+    const summary = await _findOrCreateMonthSummary(tx, userId);
+
+    const entry = await tx.financialEntry.create({
+      data: {
+        SessionID: sessionId,
+        Amount: finalPrice,
+        EntryTypeID: entryType.EntryTypeID,
+        FinancialSummaryID: summary.FinancialSummaryID,
+        CreatedAt: new Date(),
+        IsExported: false,
+      },
+    });
+
+    await tx.coachingSession.update({
+      where: { SessionID: sessionId },
+      data: { FinalPrice: finalPrice },
+    });
+
+    return entry;
+  });
+}
+
+module.exports = {
+  calculateFinalPrice,
+  applyNoShowPenalty,
+  generateFinancialEntryOnFinalization,
+};

--- a/src/services/pricing.service.js
+++ b/src/services/pricing.service.js
@@ -4,116 +4,116 @@ const OUTSIDE_HOURS_MULTIPLIER = 1.5; // BR-18
 // TODO BR-18: exact external multiplier not yet documented
 const EXTERNAL_MULTIPLIER = 1.0;
 
-async function calculateFinalPrice(sessionId) {
-  const session = await prisma.coachingSession.findUnique({
-    where: { SessionID: sessionId },
-    include: { SessionPricingRate: true },
-  });
-
-  if (!session) {
-    throw new Error(`Session ${sessionId} not found`);
-  }
-
-  const durationHours = (session.EndTime - session.StartTime) / 3_600_000;
-  let price = Number(session.SessionPricingRate.HourlyRate) * durationHours;
-
-  if (session.IsOutsideStdHours) {
-    price *= OUTSIDE_HOURS_MULTIPLIER;
-  }
-  if (session.IsExternal) {
-    price *= EXTERNAL_MULTIPLIER;
-  }
-
-  return Number(price.toFixed(2));
-}
-
-async function _findOrCreateMonthSummary(tx, userId) {
-  const now = new Date();
-  const periodStart = new Date(now.getFullYear(), now.getMonth(), 1);
-  const periodEnd = new Date(now.getFullYear(), now.getMonth() + 1, 0);
-
-  const existing = await tx.financialSummary.findFirst({
-    where: { PeriodStart: periodStart, PeriodEnd: periodEnd },
-  });
-  if (existing) return existing;
-
-  const activeYear = await tx.academicYear.findFirst({
-    where: { IsActive: true },
-  });
-  if (!activeYear) {
-    throw new Error('No active academic year found');
-  }
-
-  return tx.financialSummary.create({
-    data: {
-      PeriodStart: periodStart,
-      PeriodEnd: periodEnd,
-      GeneratedAt: now,
-      TotalAmount: 0,
-      GeneratedByUserID: userId,
-      IsExported: false,
-      AcademicYearID: activeYear.AcademicYearID,
-    },
-  });
-}
-
-async function applyNoShowPenalty(sessionId, userId) {
-  const finalPrice = await calculateFinalPrice(sessionId);
-
-  return prisma.$transaction(async (tx) => {
-    const entryType = await tx.financialEntryType.findFirst({
-      where: { TypeName: 'NOSHOWPENALTY' },
-    });
-    if (!entryType) throw new Error("FinancialEntryType 'NOSHOWPENALTY' not found");
-
-    const summary = await _findOrCreateMonthSummary(tx, userId);
-
-    return tx.financialEntry.create({
-      data: {
-        SessionID: sessionId,
-        Amount: finalPrice,
-        EntryTypeID: entryType.EntryTypeID,
-        FinancialSummaryID: summary.FinancialSummaryID,
-        CreatedAt: new Date(),
-        IsExported: false,
-      },
-    });
-  });
-}
-
-async function generateFinancialEntryOnFinalization(sessionId, userId) {
-  const finalPrice = await calculateFinalPrice(sessionId);
-
-  return prisma.$transaction(async (tx) => {
-    const entryType = await tx.financialEntryType.findFirst({
-      where: { TypeName: 'SESSION' },
-    });
-    if (!entryType) throw new Error("FinancialEntryType 'SESSION' not found");
-
-    const summary = await _findOrCreateMonthSummary(tx, userId);
-
-    const entry = await tx.financialEntry.create({
-      data: {
-        SessionID: sessionId,
-        Amount: finalPrice,
-        EntryTypeID: entryType.EntryTypeID,
-        FinancialSummaryID: summary.FinancialSummaryID,
-        CreatedAt: new Date(),
-        IsExported: false,
-      },
-    });
-
-    await tx.coachingSession.update({
+function createPricingService(prismaClient) {
+  async function calculateFinalPrice(sessionId, client = prismaClient) {
+    const session = await client.coachingSession.findUnique({
       where: { SessionID: sessionId },
-      data: { FinalPrice: finalPrice },
+      include: { SessionPricingRate: true },
     });
 
-    return entry;
-  });
+    if (!session) {
+      throw new Error(`Session ${sessionId} not found`);
+    }
+
+    const durationHours = (session.EndTime - session.StartTime) / 3_600_000;
+    let price = Number(session.SessionPricingRate.HourlyRate) * durationHours;
+
+    if (session.IsOutsideStdHours) {
+      price *= OUTSIDE_HOURS_MULTIPLIER;
+    }
+    if (session.IsExternal) {
+      price *= EXTERNAL_MULTIPLIER;
+    }
+
+    return Number(price.toFixed(2));
+  }
+
+  async function _findOrCreateMonthSummary(tx, userId) {
+    const now = new Date();
+    const year = now.getUTCFullYear();
+    const month = now.getUTCMonth();
+    const periodStart = new Date(Date.UTC(year, month, 1));
+    const periodEnd = new Date(Date.UTC(year, month + 1, 0));
+
+    const activeYear = await tx.academicYear.findFirst({
+      where: { IsActive: true },
+    });
+    if (!activeYear) {
+      throw new Error('No active academic year found');
+    }
+
+    return tx.financialSummary.upsert({
+      where: { PeriodStart_PeriodEnd: { PeriodStart: periodStart, PeriodEnd: periodEnd } },
+      update: {},
+      create: {
+        PeriodStart: periodStart,
+        PeriodEnd: periodEnd,
+        GeneratedAt: now,
+        TotalAmount: 0,
+        GeneratedByUserID: userId,
+        IsExported: false,
+        AcademicYearID: activeYear.AcademicYearID,
+      },
+    });
+  }
+
+  async function applyNoShowPenalty(sessionId, userId) {
+    return prismaClient.$transaction(async (tx) => {
+      const finalPrice = await calculateFinalPrice(sessionId, tx);
+
+      const entryType = await tx.financialEntryType.findUnique({
+        where: { TypeName: 'NOSHOWPENALTY' },
+      });
+      if (!entryType) throw new Error("FinancialEntryType 'NOSHOWPENALTY' not found");
+
+      const summary = await _findOrCreateMonthSummary(tx, userId);
+
+      return tx.financialEntry.create({
+        data: {
+          SessionID: sessionId,
+          Amount: finalPrice,
+          EntryTypeID: entryType.EntryTypeID,
+          FinancialSummaryID: summary.FinancialSummaryID,
+          CreatedAt: new Date(),
+          IsExported: false,
+        },
+      });
+    });
+  }
+
+  async function generateFinancialEntryOnFinalization(sessionId, userId) {
+    return prismaClient.$transaction(async (tx) => {
+      const finalPrice = await calculateFinalPrice(sessionId, tx);
+
+      const entryType = await tx.financialEntryType.findUnique({
+        where: { TypeName: 'SESSION' },
+      });
+      if (!entryType) throw new Error("FinancialEntryType 'SESSION' not found");
+
+      const summary = await _findOrCreateMonthSummary(tx, userId);
+
+      const entry = await tx.financialEntry.create({
+        data: {
+          SessionID: sessionId,
+          Amount: finalPrice,
+          EntryTypeID: entryType.EntryTypeID,
+          FinancialSummaryID: summary.FinancialSummaryID,
+          CreatedAt: new Date(),
+          IsExported: false,
+        },
+      });
+
+      await tx.coachingSession.update({
+        where: { SessionID: sessionId },
+        data: { FinalPrice: finalPrice },
+      });
+
+      return entry;
+    });
+  }
+
+  return { calculateFinalPrice, applyNoShowPenalty, generateFinancialEntryOnFinalization };
 }
 
-module.exports = {
-  calculateFinalPrice,
-  applyNoShowPenalty,
-  generateFinancialEntryOnFinalization,
-};
+module.exports = createPricingService(prisma);
+module.exports.createPricingService = createPricingService;

--- a/src/services/pricing.service.js
+++ b/src/services/pricing.service.js
@@ -1,5 +1,3 @@
-const prisma = require('../config/prisma');
-
 const OUTSIDE_HOURS_MULTIPLIER = 1.5; // BR-18
 // TODO BR-18: exact external multiplier not yet documented
 const EXTERNAL_MULTIPLIER = 1.0;
@@ -115,5 +113,4 @@ function createPricingService(prismaClient) {
   return { calculateFinalPrice, applyNoShowPenalty, generateFinancialEntryOnFinalization };
 }
 
-module.exports = createPricingService(prisma);
-module.exports.createPricingService = createPricingService;
+module.exports = { createPricingService };

--- a/test/unit/pricing.service.test.js
+++ b/test/unit/pricing.service.test.js
@@ -1,6 +1,6 @@
 const test = require('node:test');
 const assert = require('node:assert/strict');
-const Module = require('node:module');
+const { createPricingService } = require('../../src/services/pricing.service');
 
 const FAKE_SUMMARY = { FinancialSummaryID: 1 };
 const FAKE_YEAR = { AcademicYearID: 1 };
@@ -22,15 +22,14 @@ function makeSession({ hourlyRate = 36, durationMs = 3_600_000, isOutside = fals
 function makeFakePrisma(session, { entryCreateThrows = false, summaryExists = true } = {}) {
   const fakeTx = {
     financialEntryType: {
-      findFirst: async ({ where }) => {
+      findUnique: async ({ where }) => {
         if (where.TypeName === 'SESSION') return FAKE_SESSION_TYPE;
         if (where.TypeName === 'NOSHOWPENALTY') return FAKE_NOSHOWPENALTY_TYPE;
         return null;
       },
     },
     financialSummary: {
-      findFirst: async () => (summaryExists ? FAKE_SUMMARY : null),
-      create: async ({ data }) => ({ FinancialSummaryID: 99, ...data }),
+      upsert: async ({ create }) => (summaryExists ? FAKE_SUMMARY : { FinancialSummaryID: 99, ...create }),
     },
     academicYear: {
       findFirst: async () => FAKE_YEAR,
@@ -42,6 +41,7 @@ function makeFakePrisma(session, { entryCreateThrows = false, summaryExists = tr
       },
     },
     coachingSession: {
+      findUnique: async () => session,
       update: async () => {},
     },
   };
@@ -54,62 +54,47 @@ function makeFakePrisma(session, { entryCreateThrows = false, summaryExists = tr
   };
 }
 
-function loadService(fakePrisma) {
-  const originalLoad = Module._load;
-  Module._load = function patchedLoad(request, parent, isMain) {
-    if (request === '../config/prisma') return fakePrisma;
-    return originalLoad.call(this, request, parent, isMain);
-  };
-  // Clear cache so the module re-evaluates with the new prisma mock
-  delete require.cache[require.resolve('../../src/services/pricing.service')];
-  try {
-    return require('../../src/services/pricing.service');
-  } finally {
-    Module._load = originalLoad;
-  }
-}
-
 // --- calculateFinalPrice ---
 
 test('base price: hourlyRate × duration, no flags', async () => {
-  const svc = loadService(makeFakePrisma(makeSession({ hourlyRate: 36, durationMs: 3_600_000 })));
+  const svc = createPricingService(makeFakePrisma(makeSession({ hourlyRate: 36, durationMs: 3_600_000 })));
   const price = await svc.calculateFinalPrice(10);
   assert.equal(price, 36.00);
 });
 
 test('base price: 2-hour session at €36/h = €72', async () => {
-  const svc = loadService(makeFakePrisma(makeSession({ hourlyRate: 36, durationMs: 7_200_000 })));
+  const svc = createPricingService(makeFakePrisma(makeSession({ hourlyRate: 36, durationMs: 7_200_000 })));
   const price = await svc.calculateFinalPrice(10);
   assert.equal(price, 72.00);
 });
 
 test('isOutsideStdHours applies 1.5× multiplier', async () => {
-  const svc = loadService(makeFakePrisma(makeSession({ hourlyRate: 36, durationMs: 3_600_000, isOutside: true })));
+  const svc = createPricingService(makeFakePrisma(makeSession({ hourlyRate: 36, durationMs: 3_600_000, isOutside: true })));
   const price = await svc.calculateFinalPrice(10);
   assert.equal(price, 54.00);
 });
 
 test('isExternal applies EXTERNAL_MULTIPLIER (currently 1.0)', async () => {
-  const svc = loadService(makeFakePrisma(makeSession({ hourlyRate: 36, durationMs: 3_600_000, isExternal: true })));
+  const svc = createPricingService(makeFakePrisma(makeSession({ hourlyRate: 36, durationMs: 3_600_000, isExternal: true })));
   const price = await svc.calculateFinalPrice(10);
   assert.equal(price, 36.00);
 });
 
 test('both flags: price × 1.5 × EXTERNAL_MULTIPLIER', async () => {
-  const svc = loadService(makeFakePrisma(makeSession({ hourlyRate: 36, durationMs: 3_600_000, isOutside: true, isExternal: true })));
+  const svc = createPricingService(makeFakePrisma(makeSession({ hourlyRate: 36, durationMs: 3_600_000, isOutside: true, isExternal: true })));
   const price = await svc.calculateFinalPrice(10);
   assert.equal(price, 54.00);
 });
 
 test('throws when session not found', async () => {
-  const svc = loadService(makeFakePrisma(null));
+  const svc = createPricingService(makeFakePrisma(null));
   await assert.rejects(() => svc.calculateFinalPrice(999), /not found/);
 });
 
 // --- applyNoShowPenalty ---
 
 test('applyNoShowPenalty creates entry with NOSHOWPENALTY type and full price', async () => {
-  const svc = loadService(makeFakePrisma(makeSession({ hourlyRate: 36, durationMs: 3_600_000 })));
+  const svc = createPricingService(makeFakePrisma(makeSession({ hourlyRate: 36, durationMs: 3_600_000 })));
   const entry = await svc.applyNoShowPenalty(10, 1);
   assert.equal(entry.Amount, 36.00);
   assert.equal(entry.EntryTypeID, FAKE_NOSHOWPENALTY_TYPE.EntryTypeID);
@@ -118,13 +103,13 @@ test('applyNoShowPenalty creates entry with NOSHOWPENALTY type and full price', 
 });
 
 test('applyNoShowPenalty uses existing FinancialSummary when present', async () => {
-  const svc = loadService(makeFakePrisma(makeSession(), { summaryExists: true }));
+  const svc = createPricingService(makeFakePrisma(makeSession(), { summaryExists: true }));
   const entry = await svc.applyNoShowPenalty(10, 1);
   assert.equal(entry.FinancialSummaryID, FAKE_SUMMARY.FinancialSummaryID);
 });
 
 test('applyNoShowPenalty creates FinancialSummary when none exists for month', async () => {
-  const svc = loadService(makeFakePrisma(makeSession(), { summaryExists: false }));
+  const svc = createPricingService(makeFakePrisma(makeSession(), { summaryExists: false }));
   const entry = await svc.applyNoShowPenalty(10, 1);
   assert.equal(entry.FinancialSummaryID, 99);
 });
@@ -132,7 +117,7 @@ test('applyNoShowPenalty creates FinancialSummary when none exists for month', a
 // --- generateFinancialEntryOnFinalization ---
 
 test('generateFinancialEntryOnFinalization creates SESSION entry', async () => {
-  const svc = loadService(makeFakePrisma(makeSession({ hourlyRate: 36, durationMs: 3_600_000 })));
+  const svc = createPricingService(makeFakePrisma(makeSession({ hourlyRate: 36, durationMs: 3_600_000 })));
   const entry = await svc.generateFinancialEntryOnFinalization(10, 1);
   assert.equal(entry.Amount, 36.00);
   assert.equal(entry.EntryTypeID, FAKE_SESSION_TYPE.EntryTypeID);
@@ -143,6 +128,6 @@ test('generateFinancialEntryOnFinalization creates SESSION entry', async () => {
 // --- Transaction rollback propagation ---
 
 test('propagates error when financialEntry.create fails inside transaction', async () => {
-  const svc = loadService(makeFakePrisma(makeSession(), { entryCreateThrows: true }));
+  const svc = createPricingService(makeFakePrisma(makeSession(), { entryCreateThrows: true }));
   await assert.rejects(() => svc.generateFinancialEntryOnFinalization(10, 1), /DB failure/);
 });

--- a/test/unit/pricing.service.test.js
+++ b/test/unit/pricing.service.test.js
@@ -1,0 +1,148 @@
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const Module = require('node:module');
+
+const FAKE_SUMMARY = { FinancialSummaryID: 1 };
+const FAKE_YEAR = { AcademicYearID: 1 };
+const FAKE_SESSION_TYPE = { EntryTypeID: 2, TypeName: 'SESSION' };
+const FAKE_NOSHOWPENALTY_TYPE = { EntryTypeID: 3, TypeName: 'NOSHOWPENALTY' };
+
+function makeSession({ hourlyRate = 36, durationMs = 3_600_000, isOutside = false, isExternal = false } = {}) {
+  const start = new Date('2026-04-18T10:00:00Z');
+  return {
+    SessionID: 10,
+    StartTime: start,
+    EndTime: new Date(start.getTime() + durationMs),
+    IsOutsideStdHours: isOutside,
+    IsExternal: isExternal,
+    SessionPricingRate: { HourlyRate: hourlyRate },
+  };
+}
+
+function makeFakePrisma(session, { entryCreateThrows = false, summaryExists = true } = {}) {
+  const fakeTx = {
+    financialEntryType: {
+      findFirst: async ({ where }) => {
+        if (where.TypeName === 'SESSION') return FAKE_SESSION_TYPE;
+        if (where.TypeName === 'NOSHOWPENALTY') return FAKE_NOSHOWPENALTY_TYPE;
+        return null;
+      },
+    },
+    financialSummary: {
+      findFirst: async () => (summaryExists ? FAKE_SUMMARY : null),
+      create: async ({ data }) => ({ FinancialSummaryID: 99, ...data }),
+    },
+    academicYear: {
+      findFirst: async () => FAKE_YEAR,
+    },
+    financialEntry: {
+      create: async ({ data }) => {
+        if (entryCreateThrows) throw new Error('DB failure');
+        return { EntryID: 1, ...data };
+      },
+    },
+    coachingSession: {
+      update: async () => {},
+    },
+  };
+
+  return {
+    coachingSession: {
+      findUnique: async () => session,
+    },
+    $transaction: async (fn) => fn(fakeTx),
+  };
+}
+
+function loadService(fakePrisma) {
+  const originalLoad = Module._load;
+  Module._load = function patchedLoad(request, parent, isMain) {
+    if (request === '../config/prisma') return fakePrisma;
+    return originalLoad.call(this, request, parent, isMain);
+  };
+  // Clear cache so the module re-evaluates with the new prisma mock
+  delete require.cache[require.resolve('../../src/services/pricing.service')];
+  try {
+    return require('../../src/services/pricing.service');
+  } finally {
+    Module._load = originalLoad;
+  }
+}
+
+// --- calculateFinalPrice ---
+
+test('base price: hourlyRate × duration, no flags', async () => {
+  const svc = loadService(makeFakePrisma(makeSession({ hourlyRate: 36, durationMs: 3_600_000 })));
+  const price = await svc.calculateFinalPrice(10);
+  assert.equal(price, 36.00);
+});
+
+test('base price: 2-hour session at €36/h = €72', async () => {
+  const svc = loadService(makeFakePrisma(makeSession({ hourlyRate: 36, durationMs: 7_200_000 })));
+  const price = await svc.calculateFinalPrice(10);
+  assert.equal(price, 72.00);
+});
+
+test('isOutsideStdHours applies 1.5× multiplier', async () => {
+  const svc = loadService(makeFakePrisma(makeSession({ hourlyRate: 36, durationMs: 3_600_000, isOutside: true })));
+  const price = await svc.calculateFinalPrice(10);
+  assert.equal(price, 54.00);
+});
+
+test('isExternal applies EXTERNAL_MULTIPLIER (currently 1.0)', async () => {
+  const svc = loadService(makeFakePrisma(makeSession({ hourlyRate: 36, durationMs: 3_600_000, isExternal: true })));
+  const price = await svc.calculateFinalPrice(10);
+  assert.equal(price, 36.00);
+});
+
+test('both flags: price × 1.5 × EXTERNAL_MULTIPLIER', async () => {
+  const svc = loadService(makeFakePrisma(makeSession({ hourlyRate: 36, durationMs: 3_600_000, isOutside: true, isExternal: true })));
+  const price = await svc.calculateFinalPrice(10);
+  assert.equal(price, 54.00);
+});
+
+test('throws when session not found', async () => {
+  const svc = loadService(makeFakePrisma(null));
+  await assert.rejects(() => svc.calculateFinalPrice(999), /not found/);
+});
+
+// --- applyNoShowPenalty ---
+
+test('applyNoShowPenalty creates entry with NOSHOWPENALTY type and full price', async () => {
+  const svc = loadService(makeFakePrisma(makeSession({ hourlyRate: 36, durationMs: 3_600_000 })));
+  const entry = await svc.applyNoShowPenalty(10, 1);
+  assert.equal(entry.Amount, 36.00);
+  assert.equal(entry.EntryTypeID, FAKE_NOSHOWPENALTY_TYPE.EntryTypeID);
+  assert.equal(entry.SessionID, 10);
+  assert.equal(entry.IsExported, false);
+});
+
+test('applyNoShowPenalty uses existing FinancialSummary when present', async () => {
+  const svc = loadService(makeFakePrisma(makeSession(), { summaryExists: true }));
+  const entry = await svc.applyNoShowPenalty(10, 1);
+  assert.equal(entry.FinancialSummaryID, FAKE_SUMMARY.FinancialSummaryID);
+});
+
+test('applyNoShowPenalty creates FinancialSummary when none exists for month', async () => {
+  const svc = loadService(makeFakePrisma(makeSession(), { summaryExists: false }));
+  const entry = await svc.applyNoShowPenalty(10, 1);
+  assert.equal(entry.FinancialSummaryID, 99);
+});
+
+// --- generateFinancialEntryOnFinalization ---
+
+test('generateFinancialEntryOnFinalization creates SESSION entry', async () => {
+  const svc = loadService(makeFakePrisma(makeSession({ hourlyRate: 36, durationMs: 3_600_000 })));
+  const entry = await svc.generateFinancialEntryOnFinalization(10, 1);
+  assert.equal(entry.Amount, 36.00);
+  assert.equal(entry.EntryTypeID, FAKE_SESSION_TYPE.EntryTypeID);
+  assert.equal(entry.SessionID, 10);
+  assert.equal(entry.IsExported, false);
+});
+
+// --- Transaction rollback propagation ---
+
+test('propagates error when financialEntry.create fails inside transaction', async () => {
+  const svc = loadService(makeFakePrisma(makeSession(), { entryCreateThrows: true }));
+  await assert.rejects(() => svc.generateFinancialEntryOnFinalization(10, 1), /DB failure/);
+});


### PR DESCRIPTION
## Summary

Implement the pricing service (BE-11) to centralise all financial calculations and create FinancialEntry records. This unblocks the financial module which was previously empty.

## Changes

### Commit 1: `feat: add pricing service with financial entry creation`
- **calculateFinalPrice(sessionId)**: Computes final session price with:
  - Base rate from SessionPricingRate (€36/h default per BR-19)
  - 1.5× multiplier for outside standard hours (BR-18)
  - External multiplier (currently TODO, marked for BR-18)
- **applyNoShowPenalty(sessionId, userId)**: Transactional creation of NOSHOWPENALTY entries (100% of session price, BR-16)
- **generateFinancialEntryOnFinalization(sessionId, userId)**: Transactional creation of SESSION entries; updates session FinalPrice; auto-creates/reuses current month's FinancialSummary (BR-20)
- All DB writes wrapped in transactions; rollback on failure

### Commit 2: `test: add unit tests for pricing service`
- 11 unit tests covering:
  - Base price calculation, 2-hour sessions
  - Outside-hours 1.5× multiplier
  - External multiplier (currently 1.0)
  - Combined multipliers
  - FinancialSummary find-vs-create logic
  - NOSHOWPENALTY and SESSION entry creation
  - Transaction error propagation
