### PR TITLE
Corrigir o tipo de notificacoes permitido

### DIFF
--- a/src/controllers/notification.controller.js
+++ b/src/controllers/notification.controller.js
@@ -5,8 +5,8 @@ const ALLOWED_NOTIFICATION_TYPES = new Set([
     'coaching',
     'schedule',
     'system',
-    'penalties',
-    'join_requests',
+    'penalty',
+    'join_request',
 ]);
 
 const sendNotification = async (req, { userId, type, message }) => {
@@ -117,7 +117,6 @@ const remove = async (req, res) => {
 const create = async (req, res) => {
     try {
         const { userId, type, message } = req.body;
-
         const notification = await sendNotification(req, { userId, type, message });
         res.status(201).json(notification);
         


### PR DESCRIPTION
Done/Blocked update para o task tracker (reformulado):

Done: Reuse dos endpoints de notificações (GET /notifications, PATCH /notifications/:id/read, DELETE /notifications/:id), entrega em tempo real via WebSocket para sala user:{userId}, e broadcast geral/admin validados sem alterações de código.

Blocked (N5): falta ligar os eventos de negócio do teacher à chamada automática do helper sendNotification (booking, join request, aprovação/rejeição, no-show).

Nota técnica atualizada: os tipos já estão alinhados com o card (coaching, join_request, schedule, system, penalty). Ainda assim, o campo type continua apenas validado no controller e não persistido na BD, porque o insert mantém TypeID