### PR TITLE
feat: implement studio management backend with CRUD operations and routes

### DIFF
--- a/src/app.js
+++ b/src/app.js
@@ -9,6 +9,7 @@ const cors = require('cors');
 const helmet = require('helmet');
 const morgan = require('morgan');
 const adminRoutes = require('./routes/admin.routes');
+const adminStudiosRoutes = require('./routes/admin.studios.routes');
 const authRoutes = require('./routes/auth.routes');
 const studentRoutes = require('./routes/student.routes');
 const teacherRoutes = require('./routes/teacher.routes');
@@ -348,6 +349,7 @@ app.use('/inventory', inventoryRoutes);
 app.use('/notifications', notificationRoutes);
 app.get('/health', (req, res) => res.json({ status: 'ok' }));
 app.use('/admin', adminRoutes);
+app.use('/admin/studios', adminStudiosRoutes);
 setupSwagger(app);
 
 app.use((err, req, res, next) => {

--- a/src/controllers/studio.controller.js
+++ b/src/controllers/studio.controller.js
@@ -1,0 +1,340 @@
+const prisma = require('../config/prisma');
+
+function toInteger(value) {
+  if (typeof value === 'bigint') {
+    return Number(value);
+  }
+  const parsed = Number(value);
+  return Number.isFinite(parsed) ? parsed : 0;
+}
+
+function getAuthenticatedAdminUserId(req, res) {
+  const userId = Number(req.session?.userId);
+  const role = String(req.session?.role || '').trim().toLowerCase();
+  
+  if (!Number.isInteger(userId) || userId <= 0) {
+    res.status(401).json({ error: 'Not authenticated' });
+    return null;
+  }
+  
+  if (role !== 'admin') {
+    res.status(403).json({ error: 'Forbidden' });
+    return null;
+  }
+  
+  return userId;
+}
+
+async function getStudios(req, res, next) {
+  try {
+    const studios = await prisma.studio.findMany({
+      include: {
+        StudioModality: {
+          include: {
+            Modality: true,
+          },
+        },
+      },
+      orderBy: {
+        StudioName: 'asc',
+      },
+    });
+
+    const result = studios.map((studio) => ({
+      studioId: toInteger(studio.StudioID),
+      studioName: studio.StudioName,
+      capacity: toInteger(studio.Capacity),
+      modalities: studio.StudioModality.map((sm) => ({
+        modalityId: toInteger(sm.ModalityID),
+        modalityName: sm.Modality.ModalityName,
+      })),
+    }));
+
+    res.json(result);
+  } catch (error) {
+    next(error);
+  }
+}
+
+async function getStudioById(req, res, next) {
+  try {
+    const studioId = toInteger(req.params.id);
+    
+    if (!studioId) {
+      res.status(400).json({ error: 'Invalid studio ID' });
+      return;
+    }
+
+    const studio = await prisma.studio.findUnique({
+      where: { StudioID: studioId },
+      include: {
+        StudioModality: {
+          include: {
+            Modality: true,
+          },
+        },
+      },
+    });
+
+    if (!studio) {
+      res.status(404).json({ error: 'Studio not found' });
+      return;
+    }
+
+    const result = {
+      studioId: toInteger(studio.StudioID),
+      studioName: studio.StudioName,
+      capacity: toInteger(studio.Capacity),
+      modalities: studio.StudioModality.map((sm) => ({
+        modalityId: toInteger(sm.ModalityID),
+        modalityName: sm.Modality.ModalityName,
+      })),
+    };
+
+    res.json(result);
+  } catch (error) {
+    next(error);
+  }
+}
+
+async function createStudio(req, res, next) {
+  try {
+    const adminUserId = getAuthenticatedAdminUserId(req, res);
+    if (!adminUserId) {
+      return;
+    }
+
+    const { studioName, capacity, modalities = [] } = req.body;
+
+    if (!studioName || !capacity) {
+      res.status(400).json({ error: 'Studio name and capacity are required' });
+      return;
+    }
+
+    // Process modalities - can be IDs (numbers) or names (strings)
+    let modalityIds = [];
+    if (modalities.length > 0) {
+      // Check if modalities are objects with modalityId or modalityName
+      const hasModalityId = modalities[0]?.modalityId !== undefined;
+      const hasModalityName = modalities[0]?.modalityName !== undefined;
+
+      if (hasModalityId) {
+        // Format: [{ modalityId: 1 }, { modalityId: 2 }]
+        modalityIds = modalities.map(m => m.modalityId);
+      } else if (hasModalityName) {
+        // Format: [{ modalityName: 'Ballet' }, { modalityName: 'Jazz' }]
+        const modalityNames = modalities.map(m => m.modalityName);
+        const foundModalities = await prisma.modality.findMany({
+          where: {
+            ModalityName: {
+              in: modalityNames,
+            },
+          },
+        });
+        modalityIds = foundModalities.map(m => m.ModalityID);
+      } else {
+        // Format: ['Ballet', 'Jazz'] - names as strings
+        const modalityNames = modalities.filter(m => typeof m === 'string');
+        if (modalityNames.length > 0) {
+          const foundModalities = await prisma.modality.findMany({
+            where: {
+              ModalityName: {
+                in: modalityNames,
+              },
+            },
+          });
+          modalityIds = foundModalities.map(m => m.ModalityID);
+        }
+      }
+    }
+
+    const studio = await prisma.studio.create({
+      data: {
+        StudioName: studioName,
+        Capacity: toInteger(capacity),
+        StudioModality: modalityIds.length > 0
+          ? {
+              create: modalityIds.map((modalityId) => ({
+                ModalityID: modalityId,
+              })),
+            }
+          : undefined,
+      },
+      include: {
+        StudioModality: {
+          include: {
+            Modality: true,
+          },
+        },
+      },
+    });
+
+    const result = {
+      studioId: toInteger(studio.StudioID),
+      studioName: studio.StudioName,
+      capacity: toInteger(studio.Capacity),
+      modalities: studio.StudioModality.map((sm) => ({
+        modalityId: toInteger(sm.ModalityID),
+        modalityName: sm.Modality.ModalityName,
+      })),
+    };
+
+    res.status(201).json(result);
+  } catch (error) {
+    next(error);
+  }
+}
+
+async function updateStudio(req, res, next) {
+  try {
+    const adminUserId = getAuthenticatedAdminUserId(req, res);
+    if (!adminUserId) {
+      return;
+    }
+
+    const studioId = toInteger(req.params.id);
+    if (!studioId) {
+      res.status(400).json({ error: 'Invalid studio ID' });
+      return;
+    }
+
+    const { studioName, capacity, modalities = [] } = req.body;
+
+    const existingStudio = await prisma.studio.findUnique({
+      where: { StudioID: studioId },
+    });
+
+    if (!existingStudio) {
+      res.status(404).json({ error: 'Studio not found' });
+      return;
+    }
+
+    const updateData = {};
+
+    if (studioName !== undefined) {
+      updateData.StudioName = studioName;
+    }
+
+    if (capacity !== undefined) {
+      updateData.Capacity = toInteger(capacity);
+    }
+
+    if (modalities !== undefined) {
+      await prisma.studioModality.deleteMany({
+        where: { StudioID: studioId },
+      });
+
+      if (modalities.length > 0) {
+        let modalityIds = [];
+
+        // Check format of modalities
+        const hasModalityId = modalities[0]?.modalityId !== undefined;
+        const hasModalityName = modalities[0]?.modalityName !== undefined;
+
+        if (hasModalityId) {
+          // Format: [{ modalityId: 1 }, { modalityId: 2 }]
+          modalityIds = modalities.map(m => m.modalityId);
+        } else if (hasModalityName) {
+          // Format: [{ modalityName: 'Ballet' }, { modalityName: 'Jazz' }]
+          const modalityNames = modalities.map(m => m.modalityName);
+          const foundModalities = await prisma.modality.findMany({
+            where: {
+              ModalityName: {
+                in: modalityNames,
+              },
+            },
+          });
+          modalityIds = foundModalities.map(m => m.ModalityID);
+        } else {
+          // Format: ['Ballet', 'Jazz'] - names as strings
+          const modalityNames = modalities.filter(m => typeof m === 'string');
+          if (modalityNames.length > 0) {
+            const foundModalities = await prisma.modality.findMany({
+              where: {
+                ModalityName: {
+                  in: modalityNames,
+                },
+              },
+            });
+            modalityIds = foundModalities.map(m => m.ModalityID);
+          }
+        }
+
+        if (modalityIds.length > 0) {
+          await prisma.studioModality.createMany({
+            data: modalityIds.map((modalityId) => ({
+              StudioID: studioId,
+              ModalityID: modalityId,
+            })),
+          });
+        }
+      }
+    }
+
+    const updatedStudio = await prisma.studio.update({
+      where: { StudioID: studioId },
+      data: updateData,
+      include: {
+        StudioModality: {
+          include: {
+            Modality: true,
+          },
+        },
+      },
+    });
+
+    const result = {
+      studioId: toInteger(updatedStudio.StudioID),
+      studioName: updatedStudio.StudioName,
+      capacity: toInteger(updatedStudio.Capacity),
+      modalities: updatedStudio.StudioModality.map((sm) => ({
+        modalityId: toInteger(sm.ModalityID),
+        modalityName: sm.Modality.ModalityName,
+      })),
+    };
+
+    res.json(result);
+  } catch (error) {
+    next(error);
+  }
+}
+
+async function deleteStudio(req, res, next) {
+  try {
+    const adminUserId = getAuthenticatedAdminUserId(req, res);
+    if (!adminUserId) {
+      return;
+    }
+
+    const studioId = toInteger(req.params.id);
+    if (!studioId) {
+      res.status(400).json({ error: 'Invalid studio ID' });
+      return;
+    }
+
+    const existingStudio = await prisma.studio.findUnique({
+      where: { StudioID: studioId },
+    });
+
+    if (!existingStudio) {
+      res.status(404).json({ error: 'Studio not found' });
+      return;
+    }
+
+    await prisma.studio.delete({
+      where: { StudioID: studioId },
+    });
+
+    res.status(204).send();
+  } catch (error) {
+    next(error);
+  }
+}
+
+module.exports = {
+  getStudios,
+  getStudioById,
+  createStudio,
+  updateStudio,
+  deleteStudio,
+};

--- a/src/routes/admin.studios.routes.js
+++ b/src/routes/admin.studios.routes.js
@@ -1,0 +1,92 @@
+const express = require('express');
+const { requireAuth, requireRole } = require('../middlewares/auth.middleware');
+const studioController = require('../controllers/studio.controller');
+const prisma = require('../config/prisma');
+
+const router = express.Router();
+
+router.post('/', requireAuth, requireRole('admin'), studioController.createStudio);
+router.get('/', requireAuth, requireRole('admin'), studioController.getStudios);
+router.get('/options', requireAuth, requireRole('admin'), async (req, res, next) => {
+  try {
+    const modalities = await prisma.modality.findMany({
+      select: {
+        ModalityID: true,
+        ModalityName: true,
+      },
+      orderBy: {
+        ModalityName: 'asc',
+      },
+    });
+
+    res.json({
+      modalities: modalities.map((m) => ({
+        modalityId: m.ModalityID,
+        modalityName: m.ModalityName,
+      })),
+    });
+  } catch (error) {
+    next(error);
+  }
+});
+
+router.post('/options', requireAuth, requireRole('admin'), async (req, res, next) => {
+  try {
+    const type = String(req.body?.type || '').trim().toLowerCase();
+    const name = String(req.body?.name || '').trim();
+
+    if (!name) {
+      res.status(400).json({ error: 'Option name is required' });
+      return;
+    }
+
+    if (type !== 'modalities') {
+      // Formats are not stored in DB yet; keep compatibility with frontend flow.
+      res.status(201).json({ name });
+      return;
+    }
+
+    const existing = await prisma.modality.findFirst({
+      where: {
+        ModalityName: name,
+      },
+      select: {
+        ModalityID: true,
+        ModalityName: true,
+      },
+    });
+
+    if (existing) {
+      res.status(200).json({
+        modalityId: existing.ModalityID,
+        modalityName: existing.ModalityName,
+        name: existing.ModalityName,
+      });
+      return;
+    }
+
+    const created = await prisma.modality.create({
+      data: {
+        ModalityName: name,
+      },
+      select: {
+        ModalityID: true,
+        ModalityName: true,
+      },
+    });
+
+    res.status(201).json({
+      modalityId: created.ModalityID,
+      modalityName: created.ModalityName,
+      name: created.ModalityName,
+    });
+  } catch (error) {
+    next(error);
+  }
+});
+
+router.get('/:id', requireAuth, requireRole('admin'), studioController.getStudioById);
+router.patch('/:id', requireAuth, requireRole('admin'), studioController.updateStudio);
+router.delete('/:id', requireAuth, requireRole('admin'), studioController.deleteStudio);
+
+module.exports = router;

--- a/test/unit/studio.controller.test.js
+++ b/test/unit/studio.controller.test.js
@@ -1,0 +1,104 @@
+const { PrismaClient } = require('@prisma/client');
+const studioController = require('../../controllers/studio.controller');
+
+const prisma = new PrismaClient();
+
+describe('Studio Controller', () => {
+  beforeEach(async () => {
+    await prisma.studioModality.deleteMany();
+    await prisma.studio.deleteMany();
+  });
+
+  afterAll(async () => {
+    await prisma.$disconnect();
+  });
+
+  describe('createStudio', () => {
+    test('should create studio with modalities', async () => {
+      const req = {
+        session: { userId: 1, role: 'admin' },
+        body: {
+          studioName: 'Estúdio Teste',
+          capacity: 15,
+          modalities: [{ modalityId: 1 }, { modalityId: 2 }],
+        },
+      };
+      const res = {
+        status: jest.fn().mockReturnThis(),
+        json: jest.fn(),
+      };
+      const next = jest.fn();
+
+      await studioController.createStudio(req, res, next);
+
+      expect(res.status).toHaveBeenCalledWith(201);
+      expect(res.json).toHaveBeenCalled();
+    });
+
+    test('should return 400 if name or capacity missing', async () => {
+      const req = {
+        session: { userId: 1, role: 'admin' },
+        body: { studioName: 'Test' },
+      };
+      const res = {
+        status: jest.fn().mockReturnThis(),
+        json: jest.fn(),
+      };
+
+      await studioController.createStudio(req, res, jest.fn());
+
+      expect(res.status).toHaveBeenCalledWith(400);
+      expect(res.json).toHaveBeenCalledWith({ error: expect.any(String) });
+    });
+  });
+
+  describe('getStudios', () => {
+    test('should return list of studios', async () => {
+      const req = {};
+      const res = {
+        json: jest.fn(),
+      };
+      const next = jest.fn();
+
+      await studioController.getStudios(req, res, next);
+
+      expect(res.json).toHaveBeenCalledWith(expect.any(Array));
+    });
+  });
+
+  describe('updateStudio', () => {
+    test('should return 404 if studio not found', async () => {
+      const req = {
+        session: { userId: 1, role: 'admin' },
+        params: { id: '999' },
+        body: { studioName: 'Updated Name' },
+      };
+      const res = {
+        status: jest.fn().mockReturnThis(),
+        json: jest.fn(),
+      };
+
+      await studioController.updateStudio(req, res, jest.fn());
+
+      expect(res.status).toHaveBeenCalledWith(404);
+      expect(res.json).toHaveBeenCalledWith({ error: 'Studio not found' });
+    });
+  });
+
+  describe('deleteStudio', () => {
+    test('should return 404 if studio not found', async () => {
+      const req = {
+        session: { userId: 1, role: 'admin' },
+        params: { id: '999' },
+      };
+      const res = {
+        status: jest.fn().mockReturnThis(),
+        json: jest.fn(),
+      };
+
+      await studioController.deleteStudio(req, res, jest.fn());
+
+      expect(res.status).toHaveBeenCalledWith(404);
+    });
+  });
+});


### PR DESCRIPTION
This pull request introduces a new set of admin APIs for managing studios, including CRUD operations and modality management, along with corresponding route registration and unit tests. The changes improve the backend's ability to handle studio data in a structured and secure way, ensuring only authenticated admins can access or modify studios and their modalities.

**New Studio Management Features**

* Added a new controller (`studio.controller.js`) with full CRUD operations for studios, including handling of modalities, input validation, and admin authentication/authorization checks.
* Created new admin routes for studios in `admin.studios.routes.js`, supporting endpoints for listing, creating, updating, and deleting studios, as well as managing modality options. All routes are protected by admin authentication middleware.

**Integration and Registration**

* Registered the new admin studio routes in the main application (`app.js`) and mounted them at `/admin/studios`. [[1]](diffhunk://#diff-c72a907ac323cd2f334ed0e2bd07d15ab62581c4753660c8a0d1c681b30be4b6R12) [[2]](diffhunk://#diff-c72a907ac323cd2f334ed0e2bd07d15ab62581c4753660c8a0d1c681b30be4b6R352)

**Testing**

* Added unit tests for the new studio controller, covering scenarios such as successful creation, missing required fields, and not-found errors for update and delete operations.