### PR TITLE
38 48 implement marketplace moderation backend

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,7 @@ logs/
 instructions/
 skills/
 scratch/
+uploads/
 
 # Postman
 Postman/

--- a/package-lock.json
+++ b/package-lock.json
@@ -22,6 +22,7 @@
         "helmet": "^8.1.0",
         "morgan": "^1.10.1",
         "mssql": "^12.3.1",
+        "multer": "^2.1.1",
         "node-cron": "^4.2.1",
         "socket.io": "^4.8.3",
         "swagger-jsdoc": "^6.2.8",
@@ -957,6 +958,12 @@
         "node": ">= 8"
       }
     },
+    "node_modules/append-field": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/append-field/-/append-field-1.0.0.tgz",
+      "integrity": "sha512-klpgFSWLW1ZEs8svjfb7g4qWY0YS5imI82dTg+QahUvJ8YqAY0P10Uk8tTyh9ZGuYEZEMaeJYCF5BFuX552hsw==",
+      "license": "MIT"
+    },
     "node_modules/argparse": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
@@ -1187,6 +1194,12 @@
       "integrity": "sha512-zRpUiDwd/xk6ADqPMATG8vc9VPrkck7T07OIx0gnjmJAnHnTVXNQG3vfvWNuiZIkwu9KrKdA1iJKfsfTVxE6NA==",
       "license": "BSD-3-Clause"
     },
+    "node_modules/buffer-from": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-1.1.2.tgz",
+      "integrity": "sha512-E+XQCRwSbaaiChtv6k6Dwgc+bx+Bs6vuKJHHl5kox/BaKbhiXzqQOwK4cO22yElGp2OCmjwVhT3HmxgyPGnJfQ==",
+      "license": "MIT"
+    },
     "node_modules/bundle-name": {
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/bundle-name/-/bundle-name-4.1.0.tgz",
@@ -1200,6 +1213,17 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/busboy": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/busboy/-/busboy-1.6.0.tgz",
+      "integrity": "sha512-8SFQbg/0hQ9xy3UNTB0YEnsNBbWfhf7RtnzpL7TkBiTBRfrQ9Fxcnz7VJsleJpyp6rVLvXiuORqjlHi5q+PYuA==",
+      "dependencies": {
+        "streamsearch": "^1.1.0"
+      },
+      "engines": {
+        "node": ">=10.16.0"
       }
     },
     "node_modules/bytes": {
@@ -1426,6 +1450,21 @@
       "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
       "integrity": "sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==",
       "license": "MIT"
+    },
+    "node_modules/concat-stream": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/concat-stream/-/concat-stream-2.0.0.tgz",
+      "integrity": "sha512-MWufYdFw53ccGjCA+Ol7XJYpAlW6/prSMzuPOTRnJGcGzuhLn4Scrz7qf6o8bROZ514ltazcIFJZevcfbo0x7A==",
+      "engines": [
+        "node >= 6.0"
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "buffer-from": "^1.0.0",
+        "inherits": "^2.0.3",
+        "readable-stream": "^3.0.2",
+        "typedarray": "^0.0.6"
+      }
     },
     "node_modules/confbox": {
       "version": "0.2.4",
@@ -3066,6 +3105,68 @@
         "node": ">=16"
       }
     },
+    "node_modules/multer": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/multer/-/multer-2.1.1.tgz",
+      "integrity": "sha512-mo+QTzKlx8R7E5ylSXxWzGoXoZbOsRMpyitcht8By2KHvMbf3tjwosZ/Mu/XYU6UuJ3VZnODIrak5ZrPiPyB6A==",
+      "license": "MIT",
+      "dependencies": {
+        "append-field": "^1.0.0",
+        "busboy": "^1.6.0",
+        "concat-stream": "^2.0.0",
+        "type-is": "^1.6.18"
+      },
+      "engines": {
+        "node": ">= 10.16.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/multer/node_modules/media-typer": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/media-typer/-/media-typer-0.3.0.tgz",
+      "integrity": "sha512-dq+qelQ9akHpcOl/gUVRTxVIOkAJ1wR3QAvb4RsVjS8oVoFjDGTc679wJYmUmknUF5HwMLOgb5O+a3KxfWapPQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/multer/node_modules/mime-db": {
+      "version": "1.52.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.52.0.tgz",
+      "integrity": "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/multer/node_modules/mime-types": {
+      "version": "2.1.35",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.35.tgz",
+      "integrity": "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==",
+      "license": "MIT",
+      "dependencies": {
+        "mime-db": "1.52.0"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/multer/node_modules/type-is": {
+      "version": "1.6.18",
+      "resolved": "https://registry.npmjs.org/type-is/-/type-is-1.6.18.tgz",
+      "integrity": "sha512-TkRKr9sUTxEH8MdfuCSP7VizJyzRNMjj2J2do2Jr3Kym598JVdEksuzPQCnlFPW4ky9Q+iA+ma9BGm06XQBy8g==",
+      "license": "MIT",
+      "dependencies": {
+        "media-typer": "0.3.0",
+        "mime-types": "~2.1.24"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
     "node_modules/mysql2": {
       "version": "3.15.3",
       "resolved": "https://registry.npmjs.org/mysql2/-/mysql2-3.15.3.tgz",
@@ -4030,6 +4131,14 @@
       "devOptional": true,
       "license": "MIT"
     },
+    "node_modules/streamsearch": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/streamsearch/-/streamsearch-1.1.0.tgz",
+      "integrity": "sha512-Mcc5wHehp9aXz1ax6bZUyY5afg9u2rv5cqQI3mRrYkGC8rW2hM02jWuwjtL++LS5qinSyhj2QfLyNsuc+VsExg==",
+      "engines": {
+        "node": ">=10.0.0"
+      }
+    },
     "node_modules/string_decoder": {
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.3.0.tgz",
@@ -4214,6 +4323,12 @@
       "engines": {
         "node": ">= 0.6"
       }
+    },
+    "node_modules/typedarray": {
+      "version": "0.0.6",
+      "resolved": "https://registry.npmjs.org/typedarray/-/typedarray-0.0.6.tgz",
+      "integrity": "sha512-/aCDEGatGvZ2BIk+HmLf4ifCJFwvKFNb9/JeZPMulfgFracn9QFcAf5GO8B/mweUjSoblS5In0cWhqpfs/5PQA==",
+      "license": "MIT"
     },
     "node_modules/uid-safe": {
       "version": "2.1.5",

--- a/package.json
+++ b/package.json
@@ -36,6 +36,7 @@
     "helmet": "^8.1.0",
     "morgan": "^1.10.1",
     "mssql": "^12.3.1",
+    "multer": "^2.1.1",
     "node-cron": "^4.2.1",
     "socket.io": "^4.8.3",
     "swagger-jsdoc": "^6.2.8",

--- a/prisma/migrations/20260424_000001_marketplace_moderation_fields/migration.sql
+++ b/prisma/migrations/20260424_000001_marketplace_moderation_fields/migration.sql
@@ -1,0 +1,45 @@
+IF COL_LENGTH('dbo.MarketplaceItem', 'RejectionReason') IS NULL
+BEGIN
+    ALTER TABLE [dbo].[MarketplaceItem]
+        ADD [RejectionReason] VARCHAR(255) NULL;
+END;
+
+IF NOT EXISTS (
+    SELECT 1
+    FROM [dbo].[MarketplaceItemStatus]
+    WHERE [StatusName] = 'Pending'
+)
+BEGIN
+    INSERT INTO [dbo].[MarketplaceItemStatus] ([StatusName])
+    VALUES ('Pending');
+END;
+
+IF NOT EXISTS (
+    SELECT 1
+    FROM [dbo].[MarketplaceItemStatus]
+    WHERE [StatusName] = 'Approved'
+)
+BEGIN
+    INSERT INTO [dbo].[MarketplaceItemStatus] ([StatusName])
+    VALUES ('Approved');
+END;
+
+IF NOT EXISTS (
+    SELECT 1
+    FROM [dbo].[MarketplaceItemStatus]
+    WHERE [StatusName] = 'Rejected'
+)
+BEGIN
+    INSERT INTO [dbo].[MarketplaceItemStatus] ([StatusName])
+    VALUES ('Rejected');
+END;
+
+IF NOT EXISTS (
+    SELECT 1
+    FROM [dbo].[MarketplaceItemStatus]
+    WHERE [StatusName] = 'Removed'
+)
+BEGIN
+    INSERT INTO [dbo].[MarketplaceItemStatus] ([StatusName])
+    VALUES ('Removed');
+END;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -203,6 +203,7 @@ model MarketplaceItem {
   CategoryID               Int?
   Title                    String                   @db.VarChar(100)
   Description              String?                  @db.VarChar(255)
+  RejectionReason          String?                  @db.VarChar(255)
   Price                    Decimal                  @db.Decimal(10, 2)
   ConditionID              Int
   StatusID                 Int

--- a/src/app.js
+++ b/src/app.js
@@ -1,6 +1,7 @@
 require('dotenv').config();
 
 const crypto = require('node:crypto');
+const path = require('node:path');
 const express = require('express');
 const http = require('node:http');
 const session = require('express-session');
@@ -317,6 +318,14 @@ app.use((req, res, next) => {
   return apiCspMiddleware(req, res, next);
 });
 app.use(express.json());
+const uploadsStaticPath = path.resolve(__dirname, '..', 'uploads');
+const uploadsStaticOptions = {
+  setHeaders: (res) => {
+    res.setHeader('Cross-Origin-Resource-Policy', 'cross-origin');
+  },
+};
+app.use('/uploads', express.static(uploadsStaticPath, uploadsStaticOptions));
+app.use('/api/uploads', express.static(uploadsStaticPath, uploadsStaticOptions));
 app.use(morgan('dev'));
 if (parseBoolean(process.env.TRUST_PROXY, false)) {
   app.set('trust proxy', 1);

--- a/src/app.js
+++ b/src/app.js
@@ -9,6 +9,7 @@ const cors = require('cors');
 const helmet = require('helmet');
 const morgan = require('morgan');
 const adminRoutes = require('./routes/admin.routes');
+const adminMarketplaceRoutes = require('./routes/admin.marketplace.routes');
 const adminStudiosRoutes = require('./routes/admin.studios.routes');
 const authRoutes = require('./routes/auth.routes');
 const studentRoutes = require('./routes/student.routes');
@@ -350,6 +351,7 @@ app.use('/teacher/inventory', inventoryRoutes);
 app.use('/notifications', notificationRoutes);
 app.get('/health', (req, res) => res.json({ status: 'ok' }));
 app.use('/admin', adminRoutes);
+app.use('/admin/marketplace', adminMarketplaceRoutes);
 app.use('/admin/studios', adminStudiosRoutes);
 setupSwagger(app);
 

--- a/src/controllers/admin_marketplace.controller.js
+++ b/src/controllers/admin_marketplace.controller.js
@@ -23,6 +23,20 @@ function toMoney(value) {
   return Number(value);
 }
 
+function normalizePhotoUrl(value) {
+  if (value === null || value === undefined) {
+    return null;
+  }
+
+  return String(value)
+    .replace(/&#x2F;/gi, '/')
+    .replace(/&quot;/gi, '"')
+    .replace(/&#x27;/gi, "'")
+    .replace(/&amp;/gi, '&')
+    .replace(/&lt;/gi, '<')
+    .replace(/&gt;/gi, '>');
+}
+
 function serializeListing(record, includeSellerContact = true) {
   const seller = record.User
     ? {
@@ -63,7 +77,7 @@ function serializeListing(record, includeSellerContact = true) {
           statusName: record.MarketplaceItemStatus.StatusName,
         }
       : null,
-    photoUrl: record.PhotoURL,
+    photoUrl: normalizePhotoUrl(record.PhotoURL),
     location: record.Location,
     createdAt: record.CreatedAt,
     isActive: record.IsActive,

--- a/src/controllers/admin_marketplace.controller.js
+++ b/src/controllers/admin_marketplace.controller.js
@@ -1,0 +1,399 @@
+const prisma = require('../config/prisma');
+
+const PENDING_STATUS_NAMES = ['pending', 'pendente', 'pending_review', 'pending approval'];
+const APPROVED_STATUS_NAMES = ['approved', 'aprovado', 'published', 'publicado', 'active', 'ativo'];
+const REJECTED_STATUS_NAMES = ['rejected', 'rejeitado', 'declined', 'recusado'];
+const REMOVED_STATUS_NAMES = ['removed', 'removido', 'hidden', 'oculto', 'inactive', 'inativo'];
+
+function createHttpError(status, message) {
+  const error = new Error(message);
+  error.status = status;
+  return error;
+}
+
+function normalizeString(value) {
+  return String(value || '').trim().toLowerCase();
+}
+
+function toMoney(value) {
+  if (value === null || value === undefined) {
+    return null;
+  }
+
+  return Number(value);
+}
+
+function serializeListing(record, includeSellerContact = true) {
+  const seller = record.User
+    ? {
+        userId: record.User.UserID,
+        firstName: record.User.FirstName,
+        lastName: record.User.LastName,
+        ...(includeSellerContact
+          ? {
+              email: record.User.Email,
+              phoneNumber: record.User.PhoneNumber,
+            }
+          : {}),
+      }
+    : null;
+
+  return {
+    listingId: record.MarketplaceItemID,
+    sellerId: record.SellerID,
+    title: record.Title,
+    description: record.Description,
+    rejectionReason: record.RejectionReason ?? null,
+    price: toMoney(record.Price),
+    category: record.ItemCategory
+      ? {
+          categoryId: record.ItemCategory.CategoryID,
+          categoryName: record.ItemCategory.CategoryName,
+        }
+      : null,
+    condition: record.MarketplaceItemCondition
+      ? {
+          conditionId: record.MarketplaceItemCondition.ConditionID,
+          conditionName: record.MarketplaceItemCondition.ConditionName,
+        }
+      : null,
+    status: record.MarketplaceItemStatus
+      ? {
+          statusId: record.MarketplaceItemStatus.StatusID,
+          statusName: record.MarketplaceItemStatus.StatusName,
+        }
+      : null,
+    photoUrl: record.PhotoURL,
+    location: record.Location,
+    createdAt: record.CreatedAt,
+    isActive: record.IsActive,
+    seller,
+  };
+}
+
+function buildListingInclude(includeSellerContact = true) {
+  return {
+    ItemCategory: {
+      select: {
+        CategoryID: true,
+        CategoryName: true,
+      },
+    },
+    MarketplaceItemCondition: {
+      select: {
+        ConditionID: true,
+        ConditionName: true,
+      },
+    },
+    MarketplaceItemStatus: {
+      select: {
+        StatusID: true,
+        StatusName: true,
+      },
+    },
+    User: {
+      select: {
+        UserID: true,
+        FirstName: true,
+        LastName: true,
+        ...(includeSellerContact
+          ? {
+              Email: true,
+              PhoneNumber: true,
+            }
+          : {}),
+      },
+    },
+  };
+}
+
+async function resolveStatusId(preferredNames) {
+  const statusRows = await prisma.marketplaceItemStatus.findMany({
+    select: {
+      StatusID: true,
+      StatusName: true,
+    },
+    orderBy: {
+      StatusID: 'asc',
+    },
+  });
+
+  const expected = new Set(preferredNames.map(normalizeString));
+  const match = statusRows.find((status) => expected.has(normalizeString(status.StatusName)));
+
+  return match ? match.StatusID : null;
+}
+
+function buildCategoryFilter(rawCategory) {
+  if (rawCategory === undefined || rawCategory === null) {
+    return null;
+  }
+
+  const category = String(rawCategory).trim();
+
+  if (!category) {
+    return null;
+  }
+
+  const maybeId = Number.parseInt(category, 10);
+
+  if (!Number.isNaN(maybeId) && maybeId > 0 && String(maybeId) === category) {
+    return {
+      CategoryID: maybeId,
+    };
+  }
+
+  return {
+    ItemCategory: {
+      CategoryName: category,
+    },
+  };
+}
+
+function buildStatusFilter(rawStatus) {
+  const normalized = normalizeString(rawStatus);
+
+  if (!normalized || normalized === 'all') {
+    return null;
+  }
+
+  const aliases = {
+    pending: PENDING_STATUS_NAMES,
+    pendente: PENDING_STATUS_NAMES,
+    approved: APPROVED_STATUS_NAMES,
+    aprovado: APPROVED_STATUS_NAMES,
+    rejected: REJECTED_STATUS_NAMES,
+    rejeitado: REJECTED_STATUS_NAMES,
+    removed: REMOVED_STATUS_NAMES,
+    removido: REMOVED_STATUS_NAMES,
+  }[normalized];
+
+  if (!aliases) {
+    return {
+      MarketplaceItemStatus: {
+        StatusName: normalized,
+      },
+    };
+  }
+
+  return {
+    MarketplaceItemStatus: {
+      StatusName: {
+        in: aliases,
+      },
+    },
+  };
+}
+
+function buildSearchFilter(rawSearch) {
+  const search = String(rawSearch || '').trim();
+
+  if (!search) {
+    return null;
+  }
+
+  return {
+    OR: [
+      { Title: { contains: search } },
+      { Description: { contains: search } },
+      { Location: { contains: search } },
+      { User: { FirstName: { contains: search } } },
+      { User: { LastName: { contains: search } } },
+      { User: { Email: { contains: search } } },
+    ],
+  };
+}
+
+function buildPriceFilter(minPrice, maxPrice) {
+  if (minPrice === undefined && maxPrice === undefined) {
+    return null;
+  }
+
+  return {
+    Price: {
+      ...(minPrice !== undefined ? { gte: minPrice } : {}),
+      ...(maxPrice !== undefined ? { lte: maxPrice } : {}),
+    },
+  };
+}
+
+function mergeWhereClauses(baseWhere, clauses) {
+  for (const clause of clauses) {
+    if (!clause) {
+      continue;
+    }
+
+    if (clause.OR) {
+      baseWhere.OR = clause.OR;
+      continue;
+    }
+
+    Object.assign(baseWhere, clause);
+  }
+
+  return baseWhere;
+}
+
+async function buildListingWhere(query) {
+  const where = {};
+
+  mergeWhereClauses(where, [
+    buildCategoryFilter(query.category),
+    buildStatusFilter(query.status),
+    buildSearchFilter(query.search),
+    buildPriceFilter(query.minPrice, query.maxPrice),
+  ]);
+
+  if (query.location) {
+    where.Location = {
+      contains: query.location,
+    };
+  }
+
+  return where;
+}
+
+async function getListings(req, res, next) {
+  try {
+    const where = await buildListingWhere(req.query);
+    const listings = await prisma.marketplaceItem.findMany({
+      where,
+      include: buildListingInclude(true),
+      orderBy: {
+        CreatedAt: 'desc',
+      },
+    });
+
+    res.json({
+      listings: listings.map((listing) => serializeListing(listing, true)),
+    });
+  } catch (error) {
+    next(error);
+  }
+}
+
+async function approveListing(req, res, next) {
+  try {
+    const existing = await prisma.marketplaceItem.findUnique({
+      where: {
+        MarketplaceItemID: req.params.id,
+      },
+      select: {
+        MarketplaceItemID: true,
+      },
+    });
+
+    if (!existing) {
+      throw createHttpError(404, 'Anúncio não encontrado');
+    }
+
+    const approvedStatusId = await resolveStatusId(APPROVED_STATUS_NAMES);
+
+    if (!approvedStatusId) {
+      throw createHttpError(500, 'Estado aprovado de anúncio não configurado');
+    }
+
+    const updated = await prisma.marketplaceItem.update({
+      where: {
+        MarketplaceItemID: req.params.id,
+      },
+      data: {
+        StatusID: approvedStatusId,
+        IsActive: true,
+        RejectionReason: null,
+      },
+      include: buildListingInclude(true),
+    });
+
+    res.json({
+      listing: serializeListing(updated, true),
+    });
+  } catch (error) {
+    next(error);
+  }
+}
+
+async function rejectListing(req, res, next) {
+  try {
+    const existing = await prisma.marketplaceItem.findUnique({
+      where: {
+        MarketplaceItemID: req.params.id,
+      },
+      select: {
+        MarketplaceItemID: true,
+      },
+    });
+
+    if (!existing) {
+      throw createHttpError(404, 'Anúncio não encontrado');
+    }
+
+    const rejectedStatusId = await resolveStatusId(REJECTED_STATUS_NAMES);
+
+    if (!rejectedStatusId) {
+      throw createHttpError(500, 'Estado rejeitado de anúncio não configurado');
+    }
+
+    const reason = String(req.body.reason || '').trim();
+
+    const updated = await prisma.marketplaceItem.update({
+      where: {
+        MarketplaceItemID: req.params.id,
+      },
+      data: {
+        StatusID: rejectedStatusId,
+        IsActive: false,
+        RejectionReason: reason,
+      },
+      include: buildListingInclude(true),
+    });
+
+    res.json({
+      listing: serializeListing(updated, true),
+    });
+  } catch (error) {
+    next(error);
+  }
+}
+
+async function deleteListing(req, res, next) {
+  try {
+    const existing = await prisma.marketplaceItem.findUnique({
+      where: {
+        MarketplaceItemID: req.params.id,
+      },
+      select: {
+        MarketplaceItemID: true,
+        RejectionReason: true,
+      },
+    });
+
+    if (!existing) {
+      throw createHttpError(404, 'Anúncio não encontrado');
+    }
+
+    const removedStatusId = await resolveStatusId(REMOVED_STATUS_NAMES);
+
+    await prisma.marketplaceItem.update({
+      where: {
+        MarketplaceItemID: req.params.id,
+      },
+      data: {
+        IsActive: false,
+        ...(removedStatusId ? { StatusID: removedStatusId } : {}),
+        RejectionReason: existing.RejectionReason ?? null,
+      },
+    });
+
+    res.status(204).send();
+  } catch (error) {
+    next(error);
+  }
+}
+
+module.exports = {
+  getListings,
+  approveListing,
+  rejectListing,
+  deleteListing,
+};

--- a/src/controllers/marketplace.controller.js
+++ b/src/controllers/marketplace.controller.js
@@ -21,6 +21,20 @@ function toMoney(value) {
   return Number(value);
 }
 
+function normalizePhotoUrl(value) {
+  if (value === null || value === undefined) {
+    return null;
+  }
+
+  return String(value)
+    .replace(/&#x2F;/gi, '/')
+    .replace(/&quot;/gi, '"')
+    .replace(/&#x27;/gi, "'")
+    .replace(/&amp;/gi, '&')
+    .replace(/&lt;/gi, '<')
+    .replace(/&gt;/gi, '>');
+}
+
 function serializeListing(record, includeSellerContact = false) {
   const seller = record.User
     ? {
@@ -61,7 +75,7 @@ function serializeListing(record, includeSellerContact = false) {
         statusName: record.MarketplaceItemStatus.StatusName,
       }
       : null,
-    photoUrl: record.PhotoURL,
+    photoUrl: normalizePhotoUrl(record.PhotoURL),
     location: record.Location,
     createdAt: record.CreatedAt,
     isActive: record.IsActive,
@@ -185,6 +199,47 @@ function buildListingInclude(includeSellerContact = false) {
       },
     },
   };
+}
+
+async function getMarketplaceOptions(req, res, next) {
+  try {
+    const [categories, conditions] = await Promise.all([
+      prisma.itemCategory.findMany({
+        where: {
+          IsActive: true,
+        },
+        select: {
+          CategoryID: true,
+          CategoryName: true,
+        },
+        orderBy: {
+          CategoryName: 'asc',
+        },
+      }),
+      prisma.marketplaceItemCondition.findMany({
+        select: {
+          ConditionID: true,
+          ConditionName: true,
+        },
+        orderBy: {
+          ConditionName: 'asc',
+        },
+      }),
+    ]);
+
+    res.json({
+      categories: categories.map((entry) => ({
+        categoryId: entry.CategoryID,
+        categoryName: entry.CategoryName,
+      })),
+      conditions: conditions.map((entry) => ({
+        conditionId: entry.ConditionID,
+        conditionName: entry.ConditionName,
+      })),
+    });
+  } catch (error) {
+    next(error);
+  }
 }
 
 async function getListings(req, res, next) {
@@ -454,6 +509,7 @@ async function deleteListing(req, res, next) {
 }
 
 module.exports = {
+  getMarketplaceOptions,
   getListings,
   getListingById,
   createListing,

--- a/src/controllers/marketplace.controller.js
+++ b/src/controllers/marketplace.controller.js
@@ -1,6 +1,6 @@
 const prisma = require('../config/prisma');
 
-const DEFAULT_STATUS_NAMES = ['available', 'disponivel', 'disponível', 'active', 'ativo'];
+const PENDING_STATUS_NAMES = ['pending', 'pendente', 'pending_review', 'pending approval'];
 const REMOVED_STATUS_NAMES = ['removed', 'removido', 'hidden', 'oculto', 'inactive', 'inativo'];
 
 function createHttpError(status, message) {
@@ -41,6 +41,7 @@ function serializeListing(record, includeSellerContact = false) {
     sellerId: record.SellerID,
     title: record.Title,
     description: record.Description,
+    rejectionReason: record.RejectionReason ?? null,
     price: toMoney(record.Price),
     category: record.ItemCategory
       ? {
@@ -237,7 +238,14 @@ async function getListingById(req, res, next) {
     const listing = await prisma.marketplaceItem.findFirst({
       where: {
         MarketplaceItemID: req.params.id,
-        IsActive: true,
+        OR: [
+          {
+            IsActive: true,
+          },
+          {
+            SellerID: req.session.userId,
+          },
+        ],
       },
       include: buildListingInclude(true),
     });
@@ -259,10 +267,10 @@ async function createListing(req, res, next) {
     await ensureConditionExists(req.body.conditionId);
     await ensureCategoryExists(req.body.categoryId);
 
-    const statusId = await resolveStatusId(DEFAULT_STATUS_NAMES);
+    const statusId = await resolveStatusId(PENDING_STATUS_NAMES);
 
     if (!statusId) {
-      throw createHttpError(500, 'Estado inicial de anúncio não configurado');
+      throw createHttpError(500, 'Estado pendente de anúncio não configurado');
     }
 
     const listing = await prisma.marketplaceItem.create({
@@ -276,7 +284,8 @@ async function createListing(req, res, next) {
         StatusID: statusId,
         PhotoURL: req.body.photoUrl ?? null,
         Location: req.body.location ?? null,
-        IsActive: true,
+        RejectionReason: null,
+        IsActive: false,
       },
       include: buildListingInclude(false),
     });
@@ -323,7 +332,7 @@ async function updateListing(req, res, next) {
       },
     });
 
-    if (!existing || !existing.IsActive) {
+    if (!existing) {
       throw createHttpError(404, 'Anúncio não encontrado');
     }
 
@@ -340,6 +349,11 @@ async function updateListing(req, res, next) {
     }
 
     const updateData = {};
+    const pendingStatusId = await resolveStatusId(PENDING_STATUS_NAMES);
+
+    if (!pendingStatusId) {
+      throw createHttpError(500, 'Estado pendente de anúncio não configurado');
+    }
 
     if (req.body.title !== undefined) {
       updateData.Title = req.body.title;
@@ -369,6 +383,10 @@ async function updateListing(req, res, next) {
       updateData.Location = req.body.location;
     }
 
+    updateData.StatusID = pendingStatusId;
+    updateData.IsActive = false;
+    updateData.RejectionReason = null;
+
     const updated = await prisma.marketplaceItem.update({
       where: {
         MarketplaceItemID: listingId,
@@ -395,6 +413,7 @@ async function deleteListing(req, res, next) {
       select: {
         SellerID: true,
         IsActive: true,
+        RejectionReason: true,
       },
     });
 
@@ -414,6 +433,7 @@ async function deleteListing(req, res, next) {
     const removedStatusId = await resolveStatusId(REMOVED_STATUS_NAMES);
     const updateData = {
       IsActive: false,
+      RejectionReason: existing.RejectionReason ?? null,
     };
 
     if (removedStatusId) {

--- a/src/middlewares/marketplaceUpload.middleware.js
+++ b/src/middlewares/marketplaceUpload.middleware.js
@@ -1,0 +1,62 @@
+const path = require('node:path');
+const fs = require('node:fs');
+const multer = require('multer');
+
+const MAX_FILE_SIZE_BYTES = 5 * 1024 * 1024;
+const ALLOWED_MIME_TYPES = new Set(['image/png', 'image/jpeg', 'image/webp']);
+const UPLOADS_DIR = path.resolve(__dirname, '..', '..', 'uploads', 'marketplace');
+
+fs.mkdirSync(UPLOADS_DIR, { recursive: true });
+
+const storage = multer.diskStorage({
+  destination: UPLOADS_DIR,
+  filename: (req, file, cb) => {
+    const extension = path.extname(file.originalname || '').toLowerCase() || '.jpg';
+    const safeExtension = ['.png', '.jpg', '.jpeg', '.webp'].includes(extension) ? extension : '.jpg';
+    const uniqueSuffix = `${Date.now()}-${Math.round(Math.random() * 1e9)}`;
+    cb(null, `listing-${uniqueSuffix}${safeExtension}`);
+  },
+});
+
+const upload = multer({
+  storage,
+  limits: {
+    fileSize: MAX_FILE_SIZE_BYTES,
+  },
+  fileFilter: (req, file, cb) => {
+    if (!ALLOWED_MIME_TYPES.has(file.mimetype)) {
+      const error = new Error('Formato de imagem inválido. Usa PNG, JPG ou WEBP.');
+      error.status = 400;
+      cb(error);
+      return;
+    }
+
+    cb(null, true);
+  },
+});
+
+function attachMarketplacePhoto(req, res, next) {
+  upload.single('photo')(req, res, (error) => {
+    if (error) {
+      if (error.code === 'LIMIT_FILE_SIZE') {
+        const sizeError = new Error('Imagem demasiado grande (máximo 5MB).');
+        sizeError.status = 400;
+        next(sizeError);
+        return;
+      }
+
+      next(error);
+      return;
+    }
+
+    if (req.file) {
+      req.body.photoUrl = `/uploads/marketplace/${req.file.filename}`;
+    }
+
+    next();
+  });
+}
+
+module.exports = {
+  attachMarketplacePhoto,
+};

--- a/src/middlewares/schemas/marketplace.schema.js
+++ b/src/middlewares/schemas/marketplace.schema.js
@@ -23,8 +23,7 @@ const createMarketplaceItemSchema = [
   body('photoUrl')
     .optional({ nullable: true })
     .trim()
-    .isLength({ min: 1, max: 255 }).withMessage('Foto inválida')
-    .escape(),
+    .isLength({ min: 1, max: 255 }).withMessage('Foto inválida'),
   body('location')
     .optional({ nullable: true })
     .trim()
@@ -58,8 +57,7 @@ const updateMarketplaceItemSchema = [
   body('photoUrl')
     .optional({ nullable: true })
     .trim()
-    .isLength({ min: 1, max: 255 }).withMessage('Foto inválida')
-    .escape(),
+    .isLength({ min: 1, max: 255 }).withMessage('Foto inválida'),
   body('location')
     .optional({ nullable: true })
     .trim()

--- a/src/middlewares/schemas/marketplace.schema.js
+++ b/src/middlewares/schemas/marketplace.schema.js
@@ -121,6 +121,23 @@ const listMarketplaceListingsQuerySchema = [
     .trim()
     .isLength({ min: 1, max: 100 }).withMessage('Localização inválida')
     .escape(),
+  query('search')
+    .optional()
+    .trim()
+    .isLength({ min: 1, max: 100 }).withMessage('Pesquisa inválida')
+    .escape(),
+  query('status')
+    .optional()
+    .trim()
+    .isLength({ min: 1, max: 50 }).withMessage('Estado inválido')
+    .escape(),
+];
+
+const rejectMarketplaceListingSchema = [
+  body('reason')
+    .trim()
+    .isLength({ min: 1, max: 255 }).withMessage('Motivo de rejeição inválido')
+    .escape(),
 ];
 
 const createMarketplaceTransactionSchema = [
@@ -137,5 +154,6 @@ module.exports = {
   updateMarketplaceItemSchema,
   marketplaceListingIdParamSchema,
   listMarketplaceListingsQuerySchema,
+  rejectMarketplaceListingSchema,
   createMarketplaceTransactionSchema,
 };

--- a/src/routes/admin.marketplace.routes.js
+++ b/src/routes/admin.marketplace.routes.js
@@ -1,0 +1,48 @@
+const express = require('express');
+
+const validateRequest = require('../middlewares/validate.middleware');
+const { requireSessionAuth, requireRole } = require('../middlewares/auth.middleware');
+const {
+  marketplaceListingIdParamSchema,
+  listMarketplaceListingsQuerySchema,
+  rejectMarketplaceListingSchema,
+} = require('../middlewares/schemas/marketplace.schema');
+const adminMarketplaceController = require('../controllers/admin_marketplace.controller');
+
+const router = express.Router();
+const adminAccess = [requireSessionAuth, requireRole(['ADMIN'])];
+
+router.get(
+  '/listings',
+  ...adminAccess,
+  ...listMarketplaceListingsQuerySchema,
+  validateRequest,
+  adminMarketplaceController.getListings
+);
+
+router.patch(
+  '/listings/:id/approve',
+  ...adminAccess,
+  ...marketplaceListingIdParamSchema,
+  validateRequest,
+  adminMarketplaceController.approveListing
+);
+
+router.patch(
+  '/listings/:id/reject',
+  ...adminAccess,
+  ...marketplaceListingIdParamSchema,
+  ...rejectMarketplaceListingSchema,
+  validateRequest,
+  adminMarketplaceController.rejectListing
+);
+
+router.delete(
+  '/listings/:id',
+  ...adminAccess,
+  ...marketplaceListingIdParamSchema,
+  validateRequest,
+  adminMarketplaceController.deleteListing
+);
+
+module.exports = router;

--- a/src/routes/marketplace.routes.js
+++ b/src/routes/marketplace.routes.js
@@ -3,6 +3,7 @@ const router = express.Router();
 
 const marketplaceController = require('../controllers/marketplace.controller');
 const { APP_ROLES, requireAuth, requireRole } = require('../middlewares/auth.middleware');
+const { attachMarketplacePhoto } = require('../middlewares/marketplaceUpload.middleware');
 const validateRequest = require('../middlewares/validate.middleware');
 const {
   createMarketplaceItemSchema,
@@ -12,6 +13,8 @@ const {
 } = require('../middlewares/schemas/marketplace.schema');
 
 const marketplaceAccess = [requireAuth, requireRole(APP_ROLES)];
+
+router.get('/options', ...marketplaceAccess, marketplaceController.getMarketplaceOptions);
 
 router.get(
   '/listings',
@@ -32,6 +35,7 @@ router.get(
 router.post(
   '/listings',
   ...marketplaceAccess,
+  attachMarketplacePhoto,
   ...createMarketplaceItemSchema,
   validateRequest,
   marketplaceController.createListing
@@ -42,6 +46,7 @@ router.get('/my-listings', ...marketplaceAccess, marketplaceController.getMyList
 router.patch(
   '/listings/:id',
   ...marketplaceAccess,
+  attachMarketplacePhoto,
   ...marketplaceListingIdParamSchema,
   ...updateMarketplaceItemSchema,
   validateRequest,

--- a/test/unit/admin.marketplace.controller.test.js
+++ b/test/unit/admin.marketplace.controller.test.js
@@ -1,0 +1,234 @@
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const Module = require('node:module');
+
+const mockState = {
+  listings: [],
+  statusRows: [],
+  listingById: null,
+  lastFindManyArgs: null,
+  lastUpdateArgs: null,
+};
+
+const fakePrisma = {
+  marketplaceItemStatus: {
+    findMany: async () => mockState.statusRows,
+  },
+  marketplaceItem: {
+    findMany: async (args) => {
+      mockState.lastFindManyArgs = args;
+      return mockState.listings;
+    },
+    findUnique: async () => mockState.listingById,
+    update: async (args) => {
+      mockState.lastUpdateArgs = args;
+      return {
+        MarketplaceItemID: args.where.MarketplaceItemID,
+        SellerID: 42,
+        Title: 'Sample listing',
+        Description: 'Sample description',
+        RejectionReason: args.data.RejectionReason ?? null,
+        Price: 23.5,
+        PhotoURL: null,
+        Location: 'Viana do Castelo',
+        CreatedAt: new Date('2026-04-24T10:00:00Z'),
+        IsActive: Boolean(args.data.IsActive),
+        ItemCategory: null,
+        MarketplaceItemCondition: null,
+        MarketplaceItemStatus: {
+          StatusID: args.data.StatusID ?? 0,
+          StatusName: 'Status',
+        },
+        User: {
+          UserID: 42,
+          FirstName: 'Ana',
+          LastName: 'Silva',
+          Email: 'ana@example.com',
+          PhoneNumber: '999999999',
+        },
+      };
+    },
+  },
+};
+
+const originalLoad = Module._load;
+Module._load = function patchedLoad(request, parent, isMain) {
+  if (request === '../config/prisma') {
+    return fakePrisma;
+  }
+
+  return originalLoad.call(this, request, parent, isMain);
+};
+
+let adminMarketplaceController;
+
+try {
+  adminMarketplaceController = require('../../src/controllers/admin_marketplace.controller');
+} finally {
+  Module._load = originalLoad;
+}
+
+function createResponse() {
+  return {
+    statusCode: null,
+    payload: null,
+    status(code) {
+      this.statusCode = code;
+      return this;
+    },
+    json(body) {
+      this.payload = body;
+      return this;
+    },
+    send() {
+      return this;
+    },
+  };
+}
+
+function resetMockState() {
+  mockState.listings = [];
+  mockState.statusRows = [];
+  mockState.listingById = null;
+  mockState.lastFindManyArgs = null;
+  mockState.lastUpdateArgs = null;
+}
+
+test('getListings returns serialized marketplace listings for admin moderation', async () => {
+  resetMockState();
+
+  mockState.listings = [
+    {
+      MarketplaceItemID: 101,
+      SellerID: 10,
+      Title: 'Sapatos Jazz',
+      Description: 'Muito bons',
+      RejectionReason: null,
+      Price: 20,
+      PhotoURL: 'https://img.example/sapatos.jpg',
+      Location: 'Viana do Castelo',
+      CreatedAt: new Date('2026-04-21T10:00:00Z'),
+      IsActive: false,
+      ItemCategory: { CategoryID: 1, CategoryName: 'Calçado' },
+      MarketplaceItemCondition: { ConditionID: 2, ConditionName: 'Bom' },
+      MarketplaceItemStatus: { StatusID: 3, StatusName: 'Pending' },
+      User: {
+        UserID: 10,
+        FirstName: 'Rita',
+        LastName: 'Moreira',
+        Email: 'rita@example.com',
+        PhoneNumber: '912000000',
+      },
+    },
+  ];
+
+  const req = {
+    query: {
+      status: 'pending',
+      location: 'Viana',
+      minPrice: 5,
+      maxPrice: 40,
+    },
+  };
+  const res = createResponse();
+
+  await adminMarketplaceController.getListings(req, res, (error) => {
+    throw error;
+  });
+
+  assert.equal(Array.isArray(res.payload.listings), true);
+  assert.equal(res.payload.listings.length, 1);
+  assert.equal(res.payload.listings[0].listingId, 101);
+  assert.equal(res.payload.listings[0].status.statusName, 'Pending');
+  assert.ok(mockState.lastFindManyArgs.where);
+});
+
+test('approveListing sets listing as active and clears rejection reason', async () => {
+  resetMockState();
+
+  mockState.listingById = { MarketplaceItemID: 101 };
+  mockState.statusRows = [
+    { StatusID: 1, StatusName: 'Pending' },
+    { StatusID: 2, StatusName: 'Approved' },
+    { StatusID: 3, StatusName: 'Rejected' },
+  ];
+
+  const req = { params: { id: 101 } };
+  const res = createResponse();
+
+  await adminMarketplaceController.approveListing(req, res, (error) => {
+    throw error;
+  });
+
+  assert.equal(mockState.lastUpdateArgs.data.IsActive, true);
+  assert.equal(mockState.lastUpdateArgs.data.RejectionReason, null);
+  assert.equal(mockState.lastUpdateArgs.data.StatusID, 2);
+  assert.equal(res.payload.listing.listingId, 101);
+});
+
+test('rejectListing stores rejection reason and deactivates listing', async () => {
+  resetMockState();
+
+  mockState.listingById = { MarketplaceItemID: 102 };
+  mockState.statusRows = [
+    { StatusID: 1, StatusName: 'Pending' },
+    { StatusID: 2, StatusName: 'Approved' },
+    { StatusID: 3, StatusName: 'Rejected' },
+  ];
+
+  const req = {
+    params: { id: 102 },
+    body: { reason: 'Conteúdo não permitido' },
+  };
+  const res = createResponse();
+
+  await adminMarketplaceController.rejectListing(req, res, (error) => {
+    throw error;
+  });
+
+  assert.equal(mockState.lastUpdateArgs.data.IsActive, false);
+  assert.equal(mockState.lastUpdateArgs.data.RejectionReason, 'Conteúdo não permitido');
+  assert.equal(mockState.lastUpdateArgs.data.StatusID, 3);
+  assert.equal(res.payload.listing.listingId, 102);
+});
+
+test('deleteListing returns 204 and deactivates listing', async () => {
+  resetMockState();
+
+  mockState.listingById = {
+    MarketplaceItemID: 103,
+    RejectionReason: 'texto antigo',
+  };
+  mockState.statusRows = [
+    { StatusID: 1, StatusName: 'Pending' },
+    { StatusID: 4, StatusName: 'Removed' },
+  ];
+
+  const req = { params: { id: 103 } };
+  const res = createResponse();
+
+  await adminMarketplaceController.deleteListing(req, res, (error) => {
+    throw error;
+  });
+
+  assert.equal(mockState.lastUpdateArgs.data.IsActive, false);
+  assert.equal(mockState.lastUpdateArgs.data.StatusID, 4);
+  assert.equal(res.statusCode, 204);
+});
+
+test('approveListing yields 404 when listing does not exist', async () => {
+  resetMockState();
+
+  mockState.listingById = null;
+
+  const req = { params: { id: 999 } };
+  const res = createResponse();
+  let forwardedError = null;
+
+  await adminMarketplaceController.approveListing(req, res, (error) => {
+    forwardedError = error;
+  });
+
+  assert.ok(forwardedError);
+  assert.equal(forwardedError.status, 404);
+});


### PR DESCRIPTION
Implements the marketplace moderation backend for admins. It adds moderation endpoints to list all ads with status, approve/reject ads, and remove ads, enforces rejection reason validation, introduces rejection reason persistence in the data model, and updates listing lifecycle behavior so new/edited ads return to pending review before publication.