### PR TITLE
Add unit tests for auth, join request, and teacher controllers

### DIFF
--- a/test/unit/adminValidation.service.test.js
+++ b/test/unit/adminValidation.service.test.js
@@ -1,0 +1,306 @@
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const Module = require('node:module');
+
+// ---------------------------------------------------------------------------
+// mapQueueRow is tested indirectly via listPostSessionValidations by controlling
+// the $queryRaw response. finalizeSessionValidation is tested via the exported
+// function with a fully mocked prisma + pricingService.
+// ---------------------------------------------------------------------------
+
+// ---------------------------------------------------------------------------
+// Fake pricing service (injected via the module cache trick on pricing.service)
+// ---------------------------------------------------------------------------
+
+const fakePricingState = {
+  entryToReturn: { EntryID: 99, Amount: 36 },
+  shouldThrow: false,
+};
+
+const fakePricingService = {
+  createPricingService: () => ({
+    generateFinancialEntryOnFinalization: async () => {
+      if (fakePricingState.shouldThrow) throw new Error('pricing failure');
+      return fakePricingState.entryToReturn;
+    },
+  }),
+};
+
+// ---------------------------------------------------------------------------
+// Fake prisma state
+// ---------------------------------------------------------------------------
+
+function buildState() {
+  return {
+    session: {
+      SessionID: 10,
+      StartTime: new Date('2026-04-18T10:00:00Z'),
+      EndTime: new Date('2026-04-18T11:00:00Z'),
+    },
+    validations: [],
+    validationSteps: [
+      { StepID: 1, StepName: 'Management Finalization' },
+      { StepID: 2, StepName: 'Teacher Confirmation' },
+    ],
+    createdValidation: null,
+    queryRawRows: [],
+  };
+}
+
+let state = buildState();
+
+const fakePrisma = {
+  $queryRaw: async () => state.queryRawRows,
+  $transaction: async (fn, _opts) => fn(fakePrisma),
+  coachingSession: {
+    findUnique: async ({ where }) => {
+      if (!state.session || state.session.SessionID !== where.SessionID) return null;
+      return state.session;
+    },
+  },
+  sessionValidation: {
+    findMany: async () => state.validations,
+    create: async ({ data }) => {
+      state.createdValidation = data;
+      return data;
+    },
+  },
+  validationStep: {
+    findMany: async () => state.validationSteps,
+  },
+};
+
+// ---------------------------------------------------------------------------
+// Module patching
+// ---------------------------------------------------------------------------
+
+const originalLoad = Module._load;
+Module._load = function patchedLoad(request, parent, isMain) {
+  if (request === '../config/prisma') return fakePrisma;
+  if (request === './pricing.service') return fakePricingService;
+  return originalLoad.call(this, request, parent, isMain);
+};
+
+let adminValidationService;
+try {
+  adminValidationService = require('../../src/services/adminValidation.service');
+} finally {
+  Module._load = originalLoad;
+}
+
+function resetState(overrides = {}) {
+  state = { ...buildState(), ...overrides };
+  fakePricingState.shouldThrow = false;
+  fakePricingState.entryToReturn = { EntryID: 99, Amount: 36 };
+}
+
+// ---------------------------------------------------------------------------
+// listPostSessionValidations
+// ---------------------------------------------------------------------------
+
+test('listPostSessionValidations: returns empty array when query returns no rows', async () => {
+  resetState();
+  state.queryRawRows = [];
+
+  const result = await adminValidationService.listPostSessionValidations();
+  assert.deepEqual(result, []);
+});
+
+test('listPostSessionValidations: maps raw rows to expected shape', async () => {
+  resetState();
+  state.queryRawRows = [
+    {
+      sessionId: 5,
+      startTime: new Date('2026-04-18T10:00:00Z'),
+      endTime: new Date('2026-04-18T11:00:00Z'),
+      isExternal: 0,
+      isOutsideStdHours: 1,
+      finalPrice: 54,
+      hourlyRate: 36,
+      teacherName: 'Maria Costa',
+      studentName: 'João Alves',
+      teacherConfirmed: 1,
+      studentConfirmed: 1,
+      confirmationCount: 2,
+    },
+  ];
+
+  const result = await adminValidationService.listPostSessionValidations();
+  assert.equal(result.length, 1);
+  const item = result[0];
+  assert.equal(item.sessionId, 5);
+  assert.equal(item.sessionReference, '#5');
+  assert.equal(item.teacherName, 'Maria Costa');
+  assert.equal(item.studentName, 'João Alves');
+  assert.equal(item.hourlyRate, 36);
+  assert.equal(item.isOutsideStdHours, true);
+  assert.equal(item.isExternal, false);
+  assert.equal(item.confirmationCount, 2);
+  assert.equal(item.teacherConfirmed, true);
+  assert.equal(item.studentConfirmed, true);
+});
+
+test('listPostSessionValidations: falls back to em dash when teacherName is blank', async () => {
+  resetState();
+  state.queryRawRows = [
+    {
+      sessionId: 7,
+      startTime: new Date(),
+      endTime: new Date(),
+      isExternal: 0,
+      isOutsideStdHours: 0,
+      finalPrice: null,
+      hourlyRate: 0,
+      teacherName: '',
+      studentName: '',
+      teacherConfirmed: 1,
+      studentConfirmed: 1,
+      confirmationCount: 2,
+    },
+  ];
+
+  const result = await adminValidationService.listPostSessionValidations();
+  assert.equal(result[0].teacherName, '—');
+  assert.equal(result[0].studentName, '—');
+});
+
+// ---------------------------------------------------------------------------
+// finalizeSessionValidation
+// ---------------------------------------------------------------------------
+
+test('finalizeSessionValidation: throws 404 when session does not exist', async () => {
+  resetState();
+  state.session = null;
+
+  await assert.rejects(
+    () => adminValidationService.finalizeSessionValidation(999, 1),
+    (err) => {
+      assert.equal(err.status, 404);
+      return true;
+    },
+  );
+});
+
+test('finalizeSessionValidation: throws 409 when session has no teacher confirmation', async () => {
+  resetState();
+  // validations only from student — no teacher role
+  state.validations = [
+    {
+      ValidatedByUserID: 20,
+      ValidationStep: { StepName: 'Student Confirmation' },
+      User: { UserRole: [{ Role: { RoleName: 'student' } }] },
+    },
+  ];
+
+  await assert.rejects(
+    () => adminValidationService.finalizeSessionValidation(10, 1),
+    (err) => {
+      assert.equal(err.status, 409);
+      assert.match(err.message, /pronta/);
+      return true;
+    },
+  );
+});
+
+test('finalizeSessionValidation: throws 409 when session has no student confirmation', async () => {
+  resetState();
+  state.validations = [
+    {
+      ValidatedByUserID: 10,
+      ValidationStep: { StepName: 'Teacher Confirmation' },
+      User: { UserRole: [{ Role: { RoleName: 'teacher' } }] },
+    },
+  ];
+
+  await assert.rejects(
+    () => adminValidationService.finalizeSessionValidation(10, 1),
+    (err) => {
+      assert.equal(err.status, 409);
+      return true;
+    },
+  );
+});
+
+test('finalizeSessionValidation: throws 409 when session is already finalized', async () => {
+  resetState();
+  state.validations = [
+    {
+      ValidatedByUserID: 10,
+      ValidationStep: { StepName: 'Teacher Confirmation' },
+      User: { UserRole: [{ Role: { RoleName: 'teacher' } }] },
+    },
+    {
+      ValidatedByUserID: 20,
+      ValidationStep: { StepName: 'Student Confirmation' },
+      User: { UserRole: [{ Role: { RoleName: 'student' } }] },
+    },
+    {
+      ValidatedByUserID: 1,
+      ValidationStep: { StepName: 'Management Finalization' },
+      User: { UserRole: [{ Role: { RoleName: 'admin' } }] },
+    },
+  ];
+
+  await assert.rejects(
+    () => adminValidationService.finalizeSessionValidation(10, 1),
+    (err) => {
+      assert.equal(err.status, 409);
+      assert.match(err.message, /finalizada/);
+      return true;
+    },
+  );
+});
+
+test('finalizeSessionValidation: throws 500 when finalization step is not configured', async () => {
+  resetState();
+  state.validations = [
+    {
+      ValidatedByUserID: 10,
+      ValidationStep: { StepName: 'Teacher Confirmation' },
+      User: { UserRole: [{ Role: { RoleName: 'teacher' } }] },
+    },
+    {
+      ValidatedByUserID: 20,
+      ValidationStep: { StepName: 'Student Confirmation' },
+      User: { UserRole: [{ Role: { RoleName: 'student' } }] },
+    },
+  ];
+  // Remove the finalization step so the lookup fails
+  state.validationSteps = [{ StepID: 2, StepName: 'Teacher Confirmation' }];
+
+  await assert.rejects(
+    () => adminValidationService.finalizeSessionValidation(10, 1),
+    (err) => {
+      assert.equal(err.status, 500);
+      return true;
+    },
+  );
+});
+
+test('finalizeSessionValidation: succeeds and returns session + financialEntry', async () => {
+  resetState();
+  state.validations = [
+    {
+      ValidatedByUserID: 10,
+      ValidationStep: { StepName: 'Teacher Confirmation' },
+      User: { UserRole: [{ Role: { RoleName: 'teacher' } }] },
+    },
+    {
+      ValidatedByUserID: 20,
+      ValidationStep: { StepName: 'Student Confirmation' },
+      User: { UserRole: [{ Role: { RoleName: 'student' } }] },
+    },
+  ];
+
+  const result = await adminValidationService.finalizeSessionValidation(10, 1);
+
+  assert.ok(result.session);
+  assert.equal(result.session.SessionID, 10);
+  assert.ok(result.financialEntry);
+  assert.equal(result.financialEntry.EntryID, 99);
+  // the finalization validation record should have been created
+  assert.ok(state.createdValidation);
+  assert.equal(state.createdValidation.SessionID, 10);
+  assert.equal(state.createdValidation.ValidatedByUserID, 1);
+  assert.equal(state.createdValidation.ValidationStepID, 1); // Management Finalization StepID
+});

--- a/test/unit/auth.controller.test.js
+++ b/test/unit/auth.controller.test.js
@@ -1,0 +1,397 @@
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const Module = require('node:module');
+
+// ---------------------------------------------------------------------------
+// Shared fake state
+// ---------------------------------------------------------------------------
+
+const mockState = {
+  userByEmail: null,
+  userById: null,
+  bcryptResult: true,
+  sessionSaveError: null,
+  sessionRegenerateError: null,
+  sessionDestroyError: null,
+  loggedMessages: [],
+};
+
+// ---------------------------------------------------------------------------
+// Fake dependencies
+// ---------------------------------------------------------------------------
+
+const fakePrisma = {
+  user: {
+    findUnique: async ({ where }) => {
+      if (where?.Email !== undefined) return mockState.userByEmail;
+      if (where?.UserID !== undefined) return mockState.userById;
+      return null;
+    },
+  },
+};
+
+const fakeBcrypt = {
+  compare: async () => mockState.bcryptResult,
+};
+
+const fakeLogger = {
+  log: (entry) => mockState.loggedMessages.push(entry),
+  info: (msg, meta) => mockState.loggedMessages.push({ msg, ...meta }),
+};
+
+// ---------------------------------------------------------------------------
+// Module patching
+// ---------------------------------------------------------------------------
+
+const originalLoad = Module._load;
+Module._load = function patchedLoad(request, parent, isMain) {
+  if (request === '../config/prisma') return fakePrisma;
+  if (request === 'bcrypt') return fakeBcrypt;
+  if (request === '../utils/logger') return fakeLogger;
+  return originalLoad.call(this, request, parent, isMain);
+};
+
+let authController;
+try {
+  authController = require('../../src/controllers/auth.controller');
+} finally {
+  Module._load = originalLoad;
+}
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function createResponse() {
+  return {
+    statusCode: null,
+    payload: null,
+    status(code) { this.statusCode = code; return this; },
+    json(body) { this.payload = body; return this; },
+    send() { return this; },
+    clearCookie() { return this; },
+  };
+}
+
+function buildUser(overrides = {}) {
+  return {
+    UserID: 1,
+    AuthUID: 'ST-0001',
+    FirstName: 'Ana',
+    LastName: 'Silva',
+    Email: 'ana@test.com',
+    PasswordHash: 'hashed',
+    IsActive: true,
+    DeletedAt: null,
+    UserRole: [
+      { Role: { RoleName: 'student' } },
+    ],
+    ...overrides,
+  };
+}
+
+function buildSession(overrides = {}) {
+  let saveError = null;
+  let regenerateError = null;
+  let destroyError = null;
+
+  const session = {
+    userId: null,
+    role: null,
+    user: null,
+    cookie: { maxAge: 3600000 },
+    save(cb) { cb(saveError); },
+    regenerate(cb) { cb(regenerateError); },
+    destroy(cb) { cb(destroyError); },
+    _setSaveError(e) { saveError = e; },
+    _setRegenerateError(e) { regenerateError = e; },
+    _setDestroyError(e) { destroyError = e; },
+    ...overrides,
+  };
+
+  return session;
+}
+
+function buildApp(overrides = {}) {
+  const store = new Map();
+  store.set('sessionCookieName', 'connect.sid');
+  store.set('sessionCookieOptions', { httpOnly: true, sameSite: 'strict' });
+  Object.entries(overrides).forEach(([k, v]) => store.set(k, v));
+  return { get: (key) => store.get(key) };
+}
+
+function resetState() {
+  mockState.userByEmail = null;
+  mockState.userById = null;
+  mockState.bcryptResult = true;
+  mockState.loggedMessages = [];
+}
+
+// ---------------------------------------------------------------------------
+// login
+// ---------------------------------------------------------------------------
+
+test('login: returns 401 when user does not exist', async () => {
+  resetState();
+  mockState.userByEmail = null;
+
+  const req = {
+    body: { email: 'nope@test.com', password: 'secret' },
+    session: buildSession(),
+    app: buildApp(),
+    ip: '127.0.0.1',
+    headers: {},
+    get: () => 'test-agent',
+  };
+  const res = createResponse();
+  let nextError = null;
+  await authController.login(req, res, (err) => { nextError = err; });
+
+  assert.equal(nextError, null);
+  assert.equal(res.statusCode, 401);
+  assert.deepEqual(res.payload, { error: 'Invalid credentials' });
+});
+
+test('login: returns 401 when user is inactive', async () => {
+  resetState();
+  mockState.userByEmail = buildUser({ IsActive: false });
+
+  const req = {
+    body: { email: 'ana@test.com', password: 'secret' },
+    session: buildSession(),
+    app: buildApp(),
+    ip: '127.0.0.1',
+    headers: {},
+    get: () => 'test-agent',
+  };
+  const res = createResponse();
+  let nextError = null;
+  await authController.login(req, res, (err) => { nextError = err; });
+
+  assert.equal(nextError, null);
+  assert.equal(res.statusCode, 401);
+  assert.deepEqual(res.payload, { error: 'Invalid credentials' });
+});
+
+test('login: returns 401 when password is wrong', async () => {
+  resetState();
+  mockState.userByEmail = buildUser();
+  mockState.bcryptResult = false;
+
+  const req = {
+    body: { email: 'ana@test.com', password: 'wrong' },
+    session: buildSession(),
+    app: buildApp(),
+    ip: '127.0.0.1',
+    headers: {},
+    get: () => 'test-agent',
+  };
+  const res = createResponse();
+  let nextError = null;
+  await authController.login(req, res, (err) => { nextError = err; });
+
+  assert.equal(nextError, null);
+  assert.equal(res.statusCode, 401);
+  assert.deepEqual(res.payload, { error: 'Invalid credentials' });
+});
+
+test('login: succeeds and returns user + role', async () => {
+  resetState();
+  const user = buildUser();
+  mockState.userByEmail = user;
+  mockState.bcryptResult = true;
+
+  const session = buildSession();
+  const req = {
+    body: { email: 'ana@test.com', password: 'correct' },
+    session,
+    app: buildApp(),
+    ip: '127.0.0.1',
+    headers: {},
+    get: () => 'test-agent',
+  };
+  const res = createResponse();
+  let nextError = null;
+  await authController.login(req, res, (err) => { nextError = err; });
+
+  assert.equal(nextError, null);
+  assert.equal(res.statusCode, null, 'should not call res.status()');
+  assert.ok(res.payload?.user, 'should return user object');
+  assert.equal(res.payload.user.userId, 1);
+  assert.equal(res.payload.user.email, 'ana@test.com');
+  assert.ok(['student', 'teacher', 'admin'].includes(res.payload.role));
+  assert.equal(session.userId, 1);
+});
+
+test('login: logs a security success entry on success', async () => {
+  resetState();
+  mockState.userByEmail = buildUser();
+  mockState.bcryptResult = true;
+
+  const req = {
+    body: { email: 'ana@test.com', password: 'correct' },
+    session: buildSession(),
+    app: buildApp(),
+    ip: '10.0.0.1',
+    headers: {},
+    get: () => 'ua',
+  };
+  await authController.login(req, createResponse(), () => {});
+
+  const successLog = mockState.loggedMessages.find((m) => m.success === true);
+  assert.ok(successLog, 'expected a success audit log entry');
+});
+
+test('login: logs a security failure entry on bad password', async () => {
+  resetState();
+  mockState.userByEmail = buildUser();
+  mockState.bcryptResult = false;
+
+  const req = {
+    body: { email: 'ana@test.com', password: 'bad' },
+    session: buildSession(),
+    app: buildApp(),
+    ip: '10.0.0.1',
+    headers: {},
+    get: () => 'ua',
+  };
+  await authController.login(req, createResponse(), () => {});
+
+  const failLog = mockState.loggedMessages.find((m) => m.success === false);
+  assert.ok(failLog, 'expected a failure audit log entry');
+});
+
+// ---------------------------------------------------------------------------
+// me
+// ---------------------------------------------------------------------------
+
+test('me: returns 401 when session has no userId', async () => {
+  resetState();
+
+  const req = {
+    session: { userId: null },
+  };
+  const res = createResponse();
+  await authController.me(req, res, (err) => { assert.fail(`unexpected next: ${err}`); });
+
+  assert.equal(res.statusCode, 401);
+  assert.deepEqual(res.payload, { error: 'Not authenticated' });
+});
+
+test('me: returns 401 and destroys session when user no longer exists in DB', async () => {
+  resetState();
+  mockState.userById = null;
+
+  let sessionDestroyed = false;
+  const req = {
+    session: {
+      userId: 99,
+      destroy(cb) { sessionDestroyed = true; if (cb) cb(); },
+    },
+  };
+  const res = createResponse();
+  await authController.me(req, res, () => {});
+
+  assert.ok(sessionDestroyed);
+  assert.equal(res.statusCode, 401);
+});
+
+test('me: returns 401 and destroys session when user is inactive', async () => {
+  resetState();
+  mockState.userById = buildUser({ IsActive: false });
+
+  let sessionDestroyed = false;
+  const req = {
+    session: {
+      userId: 1,
+      destroy(cb) { sessionDestroyed = true; if (cb) cb(); },
+    },
+  };
+  const res = createResponse();
+  await authController.me(req, res, () => {});
+
+  assert.ok(sessionDestroyed);
+  assert.equal(res.statusCode, 401);
+});
+
+test('me: returns serialized user when session is valid', async () => {
+  resetState();
+  const user = buildUser();
+  mockState.userById = user;
+
+  const req = {
+    session: {
+      userId: 1,
+      role: 'student',
+      user: null,
+    },
+  };
+  const res = createResponse();
+  await authController.me(req, res, (err) => { assert.fail(`unexpected next: ${err}`); });
+
+  assert.equal(res.statusCode, null);
+  assert.ok(res.payload?.user);
+  assert.equal(res.payload.user.userId, 1);
+  assert.equal(res.payload.user.email, 'ana@test.com');
+});
+
+// ---------------------------------------------------------------------------
+// logout
+// ---------------------------------------------------------------------------
+
+test('logout: returns 204 immediately when session is null', () => {
+  const req = { session: null };
+  const res = createResponse();
+  authController.logout(req, res, (err) => { assert.fail(`unexpected next: ${err}`); });
+
+  assert.equal(res.statusCode, 204);
+});
+
+test('logout: destroys session and returns 204', (t, done) => {
+  resetState();
+  let destroyed = false;
+
+  const req = {
+    session: {
+      userId: 1,
+      destroy(cb) { destroyed = true; cb(null); },
+    },
+    app: buildApp(),
+    ip: '127.0.0.1',
+    headers: {},
+    get: () => 'ua',
+  };
+  const res = {
+    statusCode: null,
+    status(code) { this.statusCode = code; return this; },
+    send() {
+      assert.ok(destroyed);
+      assert.equal(this.statusCode, 204);
+      done();
+      return this;
+    },
+    clearCookie() { return this; },
+  };
+
+  authController.logout(req, res, (err) => { assert.fail(`unexpected next: ${err}`); });
+});
+
+test('logout: calls next with error when session.destroy fails', (t, done) => {
+  const destroyError = new Error('destroy failed');
+  const req = {
+    session: {
+      userId: 1,
+      destroy(cb) { cb(destroyError); },
+    },
+    app: buildApp(),
+    ip: '127.0.0.1',
+    headers: {},
+    get: () => 'ua',
+  };
+  const res = createResponse();
+
+  authController.logout(req, res, (err) => {
+    assert.equal(err, destroyError);
+    done();
+  });
+});

--- a/test/unit/joinRequest.service.test.js
+++ b/test/unit/joinRequest.service.test.js
@@ -1,0 +1,507 @@
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const Module = require('node:module');
+
+// ---------------------------------------------------------------------------
+// State factory
+// ---------------------------------------------------------------------------
+
+function buildState() {
+  return {
+    // Status rows returned by coachingJoinRequestStatus.findMany
+    statusRows: [
+      { StatusID: 1, StatusName: 'PendingTeacher' },
+      { StatusID: 2, StatusName: 'PendingAdmin' },
+      { StatusID: 3, StatusName: 'Approved' },
+      { StatusID: 4, StatusName: 'Rejected' },
+    ],
+    // studentAccount.findUnique result
+    studentAccount: {
+      StudentAccountID: 55,
+      User: { UserID: 10, IsActive: true, DeletedAt: null },
+    },
+    // coachingSession.findUnique result
+    session: {
+      SessionID: 20,
+      MaxParticipants: 5,
+    },
+    // How many students are already enrolled
+    enrolledCount: 0,
+    // sessionStudent.findUnique result (used by both createJoinRequest and adminApprove)
+    sessionStudentUnique: null,
+    // coachingJoinRequest.findFirst (existing open request)
+    existingOpenRequest: null,
+    // coachingJoinRequest.findUnique (for teacherApprove / teacherReject)
+    joinRequest: null,
+    // sessionTeacher.findFirst (teacher owns session)
+    teacherOwnsSession: { SessionID: 20 },
+    // Created/updated records captured
+    createdJoinRequest: null,
+    updatedJoinRequest: null,
+    // attendance statuses
+    attendanceStatuses: [{ AttendanceStatusID: 1, StatusName: 'Pending' }],
+    // sessionStudent.create captured
+    createdSessionStudent: null,
+    // notifications created
+    createdNotification: null,
+    // userRole rows for admin lookup
+    adminUserRoleRows: [],
+  };
+}
+
+let state = buildState();
+
+// ---------------------------------------------------------------------------
+// Fake prisma
+// ---------------------------------------------------------------------------
+
+const fakePrisma = {
+  $transaction: async (fn) => fn(fakePrisma),
+
+  coachingJoinRequestStatus: {
+    findMany: async () => state.statusRows,
+    findFirst: async ({ where }) => {
+      const found = state.statusRows.find(
+        (row) => row.StatusName === where.StatusName
+      );
+      return found || null;
+    },
+    create: async ({ data }) => {
+      const created = { StatusID: 99, ...data };
+      state.statusRows.push(created);
+      return created;
+    },
+  },
+
+  studentAccount: {
+    findUnique: async () => state.studentAccount,
+  },
+
+  coachingSession: {
+    findUnique: async () => state.session,
+  },
+
+  sessionStudent: {
+    count: async () => state.enrolledCount,
+    findUnique: async () => state.sessionStudentUnique,
+    create: async ({ data }) => {
+      state.createdSessionStudent = data;
+      return data;
+    },
+  },
+
+  coachingJoinRequest: {
+    findFirst: async () => state.existingOpenRequest,
+    findUnique: async () => state.joinRequest,
+    create: async ({ data }) => {
+      state.createdJoinRequest = data;
+      return {
+        JoinRequestID: 300,
+        ...data,
+        CoachingJoinRequestStatus: { StatusID: data.StatusID, StatusName: 'PendingTeacher' },
+        StudentAccount: state.studentAccount
+          ? {
+              ...state.studentAccount,
+              User: state.studentAccount.User,
+            }
+          : null,
+      };
+    },
+    update: async ({ data }) => {
+      state.updatedJoinRequest = data;
+      return {
+        JoinRequestID: state.joinRequest?.JoinRequestID || 300,
+        ...state.joinRequest,
+        ...data,
+        CoachingJoinRequestStatus: {
+          StatusID: data.StatusID,
+          StatusName: state.statusRows.find((s) => s.StatusID === data.StatusID)?.StatusName || 'Unknown',
+        },
+        StudentAccount: {
+          ...state.studentAccount,
+          User: state.studentAccount?.User,
+        },
+      };
+    },
+    findMany: async () => [],
+  },
+
+  sessionTeacher: {
+    findFirst: async () => state.teacherOwnsSession,
+    findMany: async () => [],
+  },
+
+  attendanceStatus: {
+    findMany: async () => state.attendanceStatuses,
+  },
+
+  userRole: {
+    findMany: async () => state.adminUserRoleRows,
+  },
+
+  notification: {
+    create: async ({ data }) => {
+      state.createdNotification = data;
+      return { NotificationID: 500, ...data };
+    },
+  },
+};
+
+// ---------------------------------------------------------------------------
+// Module patching
+// ---------------------------------------------------------------------------
+
+const originalLoad = Module._load;
+Module._load = function patchedLoad(request, parent, isMain) {
+  if (request === '../config/prisma') return fakePrisma;
+  return originalLoad.call(this, request, parent, isMain);
+};
+
+let joinRequestService;
+try {
+  joinRequestService = require('../../src/services/joinRequest.service');
+} finally {
+  Module._load = originalLoad;
+}
+
+function resetState(overrides = {}) {
+  state = { ...buildState(), ...overrides };
+}
+
+// ---------------------------------------------------------------------------
+// createJoinRequest
+// ---------------------------------------------------------------------------
+
+test('createJoinRequest: throws 404 when student account does not exist', async () => {
+  resetState({ studentAccount: null });
+
+  await assert.rejects(
+    () => joinRequestService.createJoinRequest({ sessionId: 20, requesterUserId: 10 }),
+    (err) => { assert.equal(err.status, 404); return true; },
+  );
+});
+
+test('createJoinRequest: throws 409 when session is full', async () => {
+  resetState({ enrolledCount: 5 });
+
+  await assert.rejects(
+    () => joinRequestService.createJoinRequest({ sessionId: 20, requesterUserId: 10 }),
+    (err) => { assert.equal(err.status, 409); assert.match(err.message, /vagas/); return true; },
+  );
+});
+
+test('createJoinRequest: throws 409 when student is already enrolled', async () => {
+  resetState({ sessionStudentUnique: { SessionID: 20 } });
+
+  await assert.rejects(
+    () => joinRequestService.createJoinRequest({ sessionId: 20, requesterUserId: 10 }),
+    (err) => { assert.equal(err.status, 409); assert.match(err.message, /inscrito/); return true; },
+  );
+});
+
+test('createJoinRequest: throws 409 when a pending request already exists', async () => {
+  resetState({ existingOpenRequest: { JoinRequestID: 1 } });
+
+  await assert.rejects(
+    () => joinRequestService.createJoinRequest({ sessionId: 20, requesterUserId: 10 }),
+    (err) => { assert.equal(err.status, 409); assert.match(err.message, /pendente/); return true; },
+  );
+});
+
+test('createJoinRequest: succeeds and returns joinRequest with teacherUserIds', async () => {
+  resetState();
+
+  const result = await joinRequestService.createJoinRequest({ sessionId: 20, requesterUserId: 10 });
+
+  assert.ok(result.joinRequest);
+  assert.equal(result.joinRequest.joinRequestId, 300);
+  assert.ok(Array.isArray(result.teacherUserIds));
+  assert.ok(state.createdJoinRequest);
+  assert.equal(state.createdJoinRequest.SessionID, 20);
+  assert.equal(state.createdJoinRequest.StudentAccountID, 55);
+});
+
+// ---------------------------------------------------------------------------
+// teacherApprove
+// ---------------------------------------------------------------------------
+
+test('teacherApprove: throws 404 when join request does not exist', async () => {
+  resetState({ joinRequest: null });
+
+  await assert.rejects(
+    () => joinRequestService.teacherApprove({ joinRequestId: 999, teacherUserId: 1 }),
+    (err) => { assert.equal(err.status, 404); return true; },
+  );
+});
+
+test('teacherApprove: throws 409 when request is not in PendingTeacher status', async () => {
+  resetState({
+    joinRequest: {
+      JoinRequestID: 1,
+      SessionID: 20,
+      StudentAccountID: 55,
+      StatusID: 2, // PendingAdmin, not PendingTeacher
+      CoachingSession: { SessionID: 20, MaxParticipants: 5 },
+      CoachingJoinRequestStatus: { StatusName: 'PendingAdmin' },
+      StudentAccount: { User: { UserID: 10 } },
+    },
+  });
+
+  await assert.rejects(
+    () => joinRequestService.teacherApprove({ joinRequestId: 1, teacherUserId: 1 }),
+    (err) => { assert.equal(err.status, 409); return true; },
+  );
+});
+
+test('teacherApprove: throws 403 when teacher does not own the session', async () => {
+  resetState({
+    joinRequest: {
+      JoinRequestID: 1,
+      SessionID: 20,
+      StudentAccountID: 55,
+      StatusID: 1, // PendingTeacher
+      CoachingSession: { SessionID: 20, MaxParticipants: 5 },
+      CoachingJoinRequestStatus: { StatusName: 'PendingTeacher' },
+      StudentAccount: { User: { UserID: 10 } },
+    },
+    teacherOwnsSession: null,
+  });
+
+  await assert.rejects(
+    () => joinRequestService.teacherApprove({ joinRequestId: 1, teacherUserId: 99 }),
+    (err) => { assert.equal(err.status, 403); return true; },
+  );
+});
+
+test('teacherApprove: succeeds and moves request to PendingAdmin', async () => {
+  resetState({
+    joinRequest: {
+      JoinRequestID: 1,
+      SessionID: 20,
+      StudentAccountID: 55,
+      StatusID: 1, // PendingTeacher
+      CoachingSession: { SessionID: 20, MaxParticipants: 5 },
+      CoachingJoinRequestStatus: { StatusName: 'PendingTeacher' },
+      StudentAccount: { User: { UserID: 10, FirstName: 'João', LastName: 'Alves', Email: 'j@a.com', IsActive: true, DeletedAt: null } },
+    },
+  });
+
+  const result = await joinRequestService.teacherApprove({ joinRequestId: 1, teacherUserId: 1 });
+
+  assert.ok(result.joinRequest);
+  // Status should have been updated to PendingAdmin (StatusID 2)
+  assert.equal(state.updatedJoinRequest.StatusID, 2);
+  assert.ok(Array.isArray(result.adminUserIds));
+});
+
+// ---------------------------------------------------------------------------
+// teacherReject
+// ---------------------------------------------------------------------------
+
+test('teacherReject: throws 404 when join request does not exist', async () => {
+  resetState({ joinRequest: null });
+
+  await assert.rejects(
+    () => joinRequestService.teacherReject({ joinRequestId: 999, teacherUserId: 1 }),
+    (err) => { assert.equal(err.status, 404); return true; },
+  );
+});
+
+test('teacherReject: throws 409 when request is not in PendingTeacher status', async () => {
+  resetState({
+    joinRequest: {
+      JoinRequestID: 1,
+      SessionID: 20,
+      StudentAccountID: 55,
+      StatusID: 2, // PendingAdmin
+      CoachingJoinRequestStatus: { StatusName: 'PendingAdmin' },
+      StudentAccount: { User: { UserID: 10, IsActive: true, DeletedAt: null } },
+    },
+    teacherOwnsSession: { SessionID: 20 },
+  });
+
+  await assert.rejects(
+    () => joinRequestService.teacherReject({ joinRequestId: 1, teacherUserId: 1 }),
+    (err) => { assert.equal(err.status, 409); return true; },
+  );
+});
+
+test('teacherReject: throws 403 when teacher does not own the session', async () => {
+  resetState({
+    joinRequest: {
+      JoinRequestID: 1,
+      SessionID: 20,
+      StudentAccountID: 55,
+      StatusID: 1,
+      CoachingJoinRequestStatus: { StatusName: 'PendingTeacher' },
+      StudentAccount: { User: { UserID: 10, IsActive: true, DeletedAt: null } },
+    },
+    teacherOwnsSession: null,
+  });
+
+  await assert.rejects(
+    () => joinRequestService.teacherReject({ joinRequestId: 1, teacherUserId: 99 }),
+    (err) => { assert.equal(err.status, 403); return true; },
+  );
+});
+
+test('teacherReject: succeeds and moves request to Rejected', async () => {
+  resetState({
+    joinRequest: {
+      JoinRequestID: 1,
+      SessionID: 20,
+      StudentAccountID: 55,
+      StatusID: 1, // PendingTeacher
+      CoachingJoinRequestStatus: { StatusName: 'PendingTeacher' },
+      StudentAccount: { User: { UserID: 10, FirstName: 'João', LastName: 'Alves', Email: 'j@a.com', IsActive: true, DeletedAt: null } },
+    },
+    teacherOwnsSession: { SessionID: 20 },
+  });
+
+  const result = await joinRequestService.teacherReject({ joinRequestId: 1, teacherUserId: 1 });
+
+  assert.ok(result.joinRequest);
+  assert.equal(state.updatedJoinRequest.StatusID, 4); // Rejected
+});
+
+// ---------------------------------------------------------------------------
+// adminApprove
+// ---------------------------------------------------------------------------
+
+test('adminApprove: throws 404 when join request does not exist', async () => {
+  resetState({ joinRequest: null });
+
+  await assert.rejects(
+    () => joinRequestService.adminApprove({ joinRequestId: 999, adminUserId: 1 }),
+    (err) => { assert.equal(err.status, 404); return true; },
+  );
+});
+
+test('adminApprove: throws 409 when request is not in PendingAdmin status', async () => {
+  resetState({
+    joinRequest: {
+      JoinRequestID: 1,
+      SessionID: 20,
+      StudentAccountID: 55,
+      StatusID: 1, // PendingTeacher
+      CoachingSession: { SessionID: 20, MaxParticipants: 5 },
+      CoachingJoinRequestStatus: { StatusName: 'PendingTeacher' },
+      StudentAccount: { User: { UserID: 10, IsActive: true, DeletedAt: null } },
+    },
+  });
+
+  await assert.rejects(
+    () => joinRequestService.adminApprove({ joinRequestId: 1, adminUserId: 1 }),
+    (err) => { assert.equal(err.status, 409); return true; },
+  );
+});
+
+test('adminApprove: throws 409 when session is already full', async () => {
+  resetState({
+    joinRequest: {
+      JoinRequestID: 1,
+      SessionID: 20,
+      StudentAccountID: 55,
+      StatusID: 2, // PendingAdmin
+      CoachingSession: { SessionID: 20, MaxParticipants: 2 },
+      CoachingJoinRequestStatus: { StatusName: 'PendingAdmin' },
+      StudentAccount: { User: { UserID: 10, IsActive: true, DeletedAt: null } },
+    },
+    enrolledCount: 2,
+  });
+
+  await assert.rejects(
+    () => joinRequestService.adminApprove({ joinRequestId: 1, adminUserId: 1 }),
+    (err) => { assert.equal(err.status, 409); return true; },
+  );
+});
+
+test('adminApprove: throws 409 when student is already enrolled', async () => {
+  resetState({
+    joinRequest: {
+      JoinRequestID: 1,
+      SessionID: 20,
+      StudentAccountID: 55,
+      StatusID: 2,
+      CoachingSession: { SessionID: 20, MaxParticipants: 5 },
+      CoachingJoinRequestStatus: { StatusName: 'PendingAdmin' },
+      StudentAccount: { User: { UserID: 10, IsActive: true, DeletedAt: null } },
+    },
+    sessionStudentUnique: { SessionID: 20 },
+  });
+
+  await assert.rejects(
+    () => joinRequestService.adminApprove({ joinRequestId: 1, adminUserId: 1 }),
+    (err) => { assert.equal(err.status, 409); assert.match(err.message, /inscrito/); return true; },
+  );
+});
+
+test('adminApprove: succeeds, creates sessionStudent, and updates request to Approved', async () => {
+  resetState({
+    joinRequest: {
+      JoinRequestID: 1,
+      SessionID: 20,
+      StudentAccountID: 55,
+      StatusID: 2, // PendingAdmin
+      CoachingSession: { SessionID: 20, MaxParticipants: 5 },
+      CoachingJoinRequestStatus: { StatusName: 'PendingAdmin' },
+      StudentAccount: { User: { UserID: 10, FirstName: 'João', LastName: 'Alves', Email: 'j@a.com', IsActive: true, DeletedAt: null } },
+    },
+  });
+
+  const result = await joinRequestService.adminApprove({ joinRequestId: 1, adminUserId: 1 });
+
+  assert.ok(result.joinRequest);
+  assert.ok(state.createdSessionStudent, 'should have created a sessionStudent record');
+  assert.equal(state.createdSessionStudent.SessionID, 20);
+  assert.equal(state.updatedJoinRequest.StatusID, 3); // Approved
+});
+
+// ---------------------------------------------------------------------------
+// adminReject
+// ---------------------------------------------------------------------------
+
+test('adminReject: throws 404 when join request does not exist', async () => {
+  resetState({ joinRequest: null });
+
+  await assert.rejects(
+    () => joinRequestService.adminReject({ joinRequestId: 999, adminUserId: 1 }),
+    (err) => { assert.equal(err.status, 404); return true; },
+  );
+});
+
+test('adminReject: throws 409 when request is not in PendingAdmin status', async () => {
+  resetState({
+    joinRequest: {
+      JoinRequestID: 1,
+      SessionID: 20,
+      StudentAccountID: 55,
+      StatusID: 1, // PendingTeacher — wrong
+      CoachingJoinRequestStatus: { StatusName: 'PendingTeacher' },
+      StudentAccount: { User: { UserID: 10, IsActive: true, DeletedAt: null } },
+    },
+  });
+
+  await assert.rejects(
+    () => joinRequestService.adminReject({ joinRequestId: 1, adminUserId: 1 }),
+    (err) => { assert.equal(err.status, 409); return true; },
+  );
+});
+
+test('adminReject: succeeds and moves request to Rejected', async () => {
+  resetState({
+    joinRequest: {
+      JoinRequestID: 1,
+      SessionID: 20,
+      StudentAccountID: 55,
+      StatusID: 2, // PendingAdmin
+      CoachingJoinRequestStatus: { StatusName: 'PendingAdmin' },
+      StudentAccount: { User: { UserID: 10, FirstName: 'João', LastName: 'Alves', Email: 'j@a.com', IsActive: true, DeletedAt: null } },
+    },
+  });
+
+  const result = await joinRequestService.adminReject({ joinRequestId: 1, adminUserId: 1 });
+
+  assert.ok(result.joinRequest);
+  assert.equal(state.updatedJoinRequest.StatusID, 4); // Rejected
+});

--- a/test/unit/teacher.controller.test.js
+++ b/test/unit/teacher.controller.test.js
@@ -1,0 +1,483 @@
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const Module = require('node:module');
+
+// ---------------------------------------------------------------------------
+// State factory
+// ---------------------------------------------------------------------------
+
+function buildState() {
+  return {
+    // coachingJoinRequest.findMany / findFirst results
+    joinRequests: [],
+    // coachingJoinRequest.findUnique (for getAdmissionRequestForTeacher)
+    joinRequestById: null,
+    // coachingJoinRequestStatus.findFirst
+    statusRows: [
+      { StatusID: 10, StatusName: 'TEACHER_APPROVED' },
+      { StatusID: 11, StatusName: 'TEACHER_REJECTED' },
+    ],
+    // counters returned by prisma.sessionTeacher.count etc.
+    classesToday: 3,
+    pendingConfirmations: 1,
+    admissionRequests: 2,
+    noShows: 0,
+    // sessionTeacher.findMany for today's schedule
+    sessionTeacherRows: [],
+    // captured values from coachingJoinRequest.update
+    updatedJoinRequestData: null,
+    // notification.create captured
+    createdNotification: null,
+  };
+}
+
+let state = buildState();
+
+// ---------------------------------------------------------------------------
+// Fake prisma
+// ---------------------------------------------------------------------------
+
+const fakePrisma = {
+  $transaction: async (fn) => fn(fakePrisma),
+
+  coachingJoinRequestStatus: {
+    findFirst: async ({ where }) => {
+      return state.statusRows.find((s) => s.StatusName === where.StatusName) || null;
+    },
+    create: async ({ data }) => {
+      const created = { StatusID: 99, ...data };
+      state.statusRows.push(created);
+      return created;
+    },
+  },
+
+  coachingJoinRequest: {
+    findFirst: async () => state.joinRequestById,
+    findMany: async () => state.joinRequests,
+    update: async ({ data }) => {
+      state.updatedJoinRequestData = data;
+      return {
+        JoinRequestID: state.joinRequestById?.JoinRequestID || 1,
+        ...state.joinRequestById,
+        ...data,
+        CoachingJoinRequestStatus: {
+          StatusID: data.StatusID,
+          StatusName: state.statusRows.find((s) => s.StatusID === data.StatusID)?.StatusName || 'Unknown',
+        },
+        StudentAccount: {
+          UserID: 20,
+          User: {
+            UserID: 20,
+            FirstName: 'João',
+            LastName: 'Alves',
+            Email: 'j@a.com',
+          },
+        },
+      };
+    },
+    count: async () => state.admissionRequests,
+  },
+
+  sessionTeacher: {
+    count: async ({ where }) => {
+      if (where?.CoachingSession?.StartTime) return state.classesToday;
+      return state.pendingConfirmations;
+    },
+    findMany: async () => state.sessionTeacherRows,
+  },
+
+  sessionStudent: {
+    count: async () => state.noShows,
+  },
+
+  notification: {
+    create: async ({ data }) => {
+      state.createdNotification = data;
+      return { NotificationID: 500, ...data };
+    },
+  },
+};
+
+// ---------------------------------------------------------------------------
+// Module patching
+// ---------------------------------------------------------------------------
+
+const originalLoad = Module._load;
+Module._load = function patchedLoad(request, parent, isMain) {
+  if (request === '../config/prisma') return fakePrisma;
+  return originalLoad.call(this, request, parent, isMain);
+};
+
+let teacherController;
+try {
+  teacherController = require('../../src/controllers/teacher.controller');
+} finally {
+  Module._load = originalLoad;
+}
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function createResponse() {
+  return {
+    statusCode: null,
+    payload: null,
+    status(code) { this.statusCode = code; return this; },
+    json(body) { this.payload = body; return this; },
+  };
+}
+
+function buildSession({ userId = 1, role = 'teacher' } = {}) {
+  return { userId, role };
+}
+
+function resetState(overrides = {}) {
+  state = { ...buildState(), ...overrides };
+}
+
+function buildJoinRequest(overrides = {}) {
+  return {
+    JoinRequestID: 1,
+    SessionID: 20,
+    StudentAccountID: 55,
+    ReviewedAt: null,
+    ReviewedByUserID: null,
+    CoachingJoinRequestStatus: { StatusName: 'PendingTeacher' },
+    StudentAccount: {
+      GuardianName: null,
+      User: {
+        UserID: 20,
+        FirstName: 'João',
+        LastName: 'Alves',
+        Email: 'j@a.com',
+      },
+    },
+    CoachingSession: {
+      SessionID: 20,
+      StartTime: new Date('2026-04-18T10:00:00Z'),
+      EndTime: new Date('2026-04-18T11:00:00Z'),
+      MaxParticipants: 5,
+      Studio: { StudioName: 'Sala A' },
+      Modality: { ModalityName: 'Ballet' },
+      _count: { SessionStudent: 2 },
+    },
+    ...overrides,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// getAuthenticatedTeacherUserId (tested indirectly through getDashboard)
+// ---------------------------------------------------------------------------
+
+test('getDashboard: returns 401 when session has no userId', async () => {
+  resetState();
+  const req = { session: { userId: null, role: 'teacher' } };
+  const res = createResponse();
+  await teacherController.getDashboard(req, res, (err) => { assert.fail(`unexpected next: ${err}`); });
+
+  assert.equal(res.statusCode, 401);
+  assert.deepEqual(res.payload, { error: 'Not authenticated' });
+});
+
+test('getDashboard: returns 403 when role is not teacher', async () => {
+  resetState();
+  const req = { session: { userId: 1, role: 'student' } };
+  const res = createResponse();
+  await teacherController.getDashboard(req, res, (err) => { assert.fail(`unexpected next: ${err}`); });
+
+  assert.equal(res.statusCode, 403);
+  assert.deepEqual(res.payload, { error: 'Forbidden' });
+});
+
+test('getDashboard: returns KPI counts for authenticated teacher', async () => {
+  resetState({ classesToday: 2, pendingConfirmations: 1, admissionRequests: 3, noShows: 0 });
+
+  const req = { session: buildSession() };
+  const res = createResponse();
+  await teacherController.getDashboard(req, res, (err) => { assert.fail(`unexpected next: ${err}`); });
+
+  assert.equal(res.statusCode, null);
+  assert.ok(typeof res.payload.classesToday === 'number');
+  assert.ok(typeof res.payload.admissionRequests === 'number');
+  assert.ok(typeof res.payload.noShows === 'number');
+});
+
+// ---------------------------------------------------------------------------
+// getAdmissionRequests / getPendingAdmissions
+// ---------------------------------------------------------------------------
+
+test('getPendingAdmissions: returns 401 when not authenticated', async () => {
+  resetState();
+  const req = { session: { userId: null, role: 'teacher' } };
+  const res = createResponse();
+  await teacherController.getPendingAdmissions(req, res, () => {});
+
+  assert.equal(res.statusCode, 401);
+});
+
+test('getPendingAdmissions: returns empty requests array when no pending admissions', async () => {
+  resetState({ joinRequests: [] });
+
+  const req = { session: buildSession() };
+  const res = createResponse();
+  await teacherController.getPendingAdmissions(req, res, (err) => { assert.fail(`unexpected next: ${err}`); });
+
+  assert.equal(res.statusCode, null);
+  assert.ok(Array.isArray(res.payload.requests));
+  assert.equal(res.payload.requests.length, 0);
+  assert.equal(res.payload.summary.pendingRequests, 0);
+});
+
+test('getPendingAdmissions: returns mapped admission requests', async () => {
+  resetState();
+  // The prisma.coachingJoinRequest.findMany returns an array that the controller maps
+  state.joinRequests = [
+    {
+      JoinRequestID: 1,
+      SessionID: 20,
+      StudentAccountID: 55,
+      ReviewedAt: null,
+      ReviewedByUserID: null,
+      CoachingJoinRequestStatus: { StatusName: 'PendingTeacher' },
+      StudentAccount: {
+        GuardianName: 'Guardian',
+        User: { UserID: 20, FirstName: 'João', LastName: 'Alves', Email: 'j@a.com' },
+      },
+      CoachingSession: {
+        SessionID: 20,
+        StartTime: new Date('2026-04-18T10:00:00Z'),
+        EndTime: new Date('2026-04-18T11:00:00Z'),
+        MaxParticipants: 5,
+        Studio: { StudioName: 'Sala A' },
+        Modality: { ModalityName: 'Ballet' },
+        _count: { SessionStudent: 2 },
+      },
+    },
+  ];
+
+  const req = { session: buildSession() };
+  const res = createResponse();
+  await teacherController.getPendingAdmissions(req, res, (err) => { assert.fail(`unexpected next: ${err}`); });
+
+  assert.equal(res.statusCode, null);
+  assert.equal(res.payload.requests.length, 1);
+  assert.equal(res.payload.summary.pendingRequests, 1);
+  const r = res.payload.requests[0];
+  assert.equal(r.joinRequestId, 1);
+  assert.equal(r.studentName, 'João Alves');
+  assert.equal(r.studioName, 'Sala A');
+});
+
+// ---------------------------------------------------------------------------
+// reviewAdmissionRequest / applyAdmissionDecision
+// ---------------------------------------------------------------------------
+
+test('reviewAdmissionRequest: returns 401 when not authenticated', async () => {
+  resetState();
+  const req = {
+    session: { userId: null, role: 'teacher' },
+    params: { joinRequestId: '1' },
+    body: { decision: 'approve' },
+  };
+  const res = createResponse();
+  await teacherController.reviewAdmissionRequest(req, res, () => {});
+
+  assert.equal(res.statusCode, 401);
+});
+
+test('reviewAdmissionRequest: returns 400 for invalid joinRequestId', async () => {
+  resetState();
+  const req = {
+    session: buildSession(),
+    params: { joinRequestId: 'abc' },
+    body: { decision: 'approve' },
+  };
+  const res = createResponse();
+  await teacherController.reviewAdmissionRequest(req, res, () => {});
+
+  assert.equal(res.statusCode, 400);
+  assert.match(res.payload.error, /joinRequestId/i);
+});
+
+test('reviewAdmissionRequest: returns 400 for invalid decision', async () => {
+  resetState();
+  const req = {
+    session: buildSession(),
+    params: { joinRequestId: '1' },
+    body: { decision: 'maybe' },
+  };
+  const res = createResponse();
+  await teacherController.reviewAdmissionRequest(req, res, () => {});
+
+  assert.equal(res.statusCode, 400);
+  assert.match(res.payload.error, /decision/i);
+});
+
+test('reviewAdmissionRequest: returns 400 when rejecting without observations', async () => {
+  resetState({ joinRequestById: buildJoinRequest() });
+
+  const req = {
+    session: buildSession(),
+    params: { joinRequestId: '1' },
+    body: { decision: 'reject', observations: '' },
+  };
+  const res = createResponse();
+  await teacherController.reviewAdmissionRequest(req, res, () => {});
+
+  assert.equal(res.statusCode, 400);
+  assert.match(res.payload.error, /observations/i);
+});
+
+test('reviewAdmissionRequest: returns 404 when join request not found for this teacher', async () => {
+  resetState({ joinRequestById: null });
+
+  const req = {
+    session: buildSession(),
+    params: { joinRequestId: '1' },
+    body: { decision: 'approve' },
+  };
+  const res = createResponse();
+  await teacherController.reviewAdmissionRequest(req, res, () => {});
+
+  assert.equal(res.statusCode, 404);
+});
+
+test('reviewAdmissionRequest: returns 409 when request was already reviewed', async () => {
+  resetState({
+    joinRequestById: buildJoinRequest({
+      ReviewedAt: new Date('2026-04-10T10:00:00Z'),
+      ReviewedByUserID: 1,
+    }),
+  });
+
+  const req = {
+    session: buildSession(),
+    params: { joinRequestId: '1' },
+    body: { decision: 'approve' },
+  };
+  const res = createResponse();
+  await teacherController.reviewAdmissionRequest(req, res, () => {});
+
+  assert.equal(res.statusCode, 409);
+});
+
+test('reviewAdmissionRequest: approve succeeds and returns updated request', async () => {
+  resetState({ joinRequestById: buildJoinRequest() });
+
+  const req = {
+    session: buildSession(),
+    params: { joinRequestId: '1' },
+    body: { decision: 'approve', observations: '' },
+  };
+  const res = createResponse();
+  await teacherController.reviewAdmissionRequest(req, res, (err) => { assert.fail(`unexpected next: ${err}`); });
+
+  assert.equal(res.statusCode, null);
+  assert.ok(res.payload?.request);
+  assert.ok(state.createdNotification, 'should create a notification');
+});
+
+test('reviewAdmissionRequest: reject succeeds with observations', async () => {
+  resetState({ joinRequestById: buildJoinRequest() });
+
+  const req = {
+    session: buildSession(),
+    params: { joinRequestId: '1' },
+    body: { decision: 'reject', observations: 'Capacidade esgotada.' },
+  };
+  const res = createResponse();
+  await teacherController.reviewAdmissionRequest(req, res, (err) => { assert.fail(`unexpected next: ${err}`); });
+
+  assert.equal(res.statusCode, null);
+  assert.ok(res.payload?.request);
+  assert.ok(state.createdNotification);
+});
+
+// ---------------------------------------------------------------------------
+// approveJoinRequest / rejectJoinRequest (shortcut handlers)
+// ---------------------------------------------------------------------------
+
+test('approveJoinRequest: forces decision=approve regardless of body', async () => {
+  resetState({ joinRequestById: buildJoinRequest() });
+
+  const req = {
+    session: buildSession(),
+    params: { joinRequestId: '1' },
+    body: {}, // no decision in body — forced by the handler
+  };
+  const res = createResponse();
+  await teacherController.approveJoinRequest(req, res, (err) => { assert.fail(`unexpected next: ${err}`); });
+
+  assert.equal(res.statusCode, null);
+  assert.ok(res.payload?.request);
+});
+
+test('rejectJoinRequest: forces decision=reject, returns 400 without observations', async () => {
+  resetState({ joinRequestById: buildJoinRequest() });
+
+  const req = {
+    session: buildSession(),
+    params: { joinRequestId: '1' },
+    body: { observations: '' },
+  };
+  const res = createResponse();
+  await teacherController.rejectJoinRequest(req, res, () => {});
+
+  assert.equal(res.statusCode, 400);
+});
+
+// ---------------------------------------------------------------------------
+// getTodaySchedule
+// ---------------------------------------------------------------------------
+
+test('getTodaySchedule: returns 401 when not authenticated', async () => {
+  resetState();
+  const req = { session: { userId: null, role: 'teacher' } };
+  const res = createResponse();
+  await teacherController.getTodaySchedule(req, res, () => {});
+
+  assert.equal(res.statusCode, 401);
+});
+
+test('getTodaySchedule: returns empty schedule array when no sessions today', async () => {
+  resetState({ sessionTeacherRows: [] });
+
+  const req = { session: buildSession() };
+  const res = createResponse();
+  await teacherController.getTodaySchedule(req, res, (err) => { assert.fail(`unexpected next: ${err}`); });
+
+  assert.equal(res.statusCode, null);
+  assert.ok(Array.isArray(res.payload.schedule));
+  assert.equal(res.payload.schedule.length, 0);
+});
+
+test('getTodaySchedule: maps session rows to expected shape', async () => {
+  resetState({
+    sessionTeacherRows: [
+      {
+        SessionID: 20,
+        CoachingSession: {
+          SessionID: 20,
+          StartTime: new Date('2026-04-26T09:00:00Z'),
+          EndTime: new Date('2026-04-26T10:00:00Z'),
+          Studio: { StudioName: 'Sala A' },
+          SessionStatus: { StatusName: 'Confirmed' },
+          _count: { SessionStudent: 3 },
+        },
+      },
+    ],
+  });
+
+  const req = { session: buildSession() };
+  const res = createResponse();
+  await teacherController.getTodaySchedule(req, res, (err) => { assert.fail(`unexpected next: ${err}`); });
+
+  assert.equal(res.statusCode, null);
+  assert.equal(res.payload.schedule.length, 1);
+  const entry = res.payload.schedule[0];
+  assert.equal(entry.sessionId, 20);
+  assert.equal(entry.studio, 'Sala A');
+  assert.equal(entry.status, 'Confirmed');
+  assert.equal(entry.studentCount, 3);
+});


### PR DESCRIPTION
- Implement comprehensive tests for the auth controller, covering login and session management scenarios.
- Create tests for the join request service, validating the join request creation and approval processes.
- Develop tests for the teacher controller, ensuring proper handling of admission requests and daily schedules.

Add unit tests for auth.controller, adminValidation.service, joinRequest.service and teacher.controller — covering authentication flows, session finalization, join request state transitions and teacher admission decisions. All 151 unit tests pass.