### PR TITLE
Refactor financial entry type names for consistency

### DIFF
--- a/src/middlewares/schemas/finance.schema.js
+++ b/src/middlewares/schemas/finance.schema.js
@@ -1,6 +1,12 @@
 const { body, query } = require('express-validator');
 
-const KNOWN_ENTRY_TYPES = ['SESSION', 'NOSHOWPENALTY', 'CANCELLATIONFEE'];
+const KNOWN_ENTRY_TYPES = [
+  'session_revenue',
+  'no_show_fee',
+  'cancellation_fee',
+  'inventory_fee',
+  'marketplace_fee',
+];
 
 const periodStartQuery = query('periodStart')
   .optional()

--- a/src/services/adminDashboard.service.js
+++ b/src/services/adminDashboard.service.js
@@ -70,7 +70,7 @@ async function getMonthlyRevenue(referenceDate = new Date()) {
         lt: end,
       },
       FinancialEntryType: {
-        TypeName: 'SESSION',
+        TypeName: 'session_revenue',
       },
     },
   });

--- a/src/services/finance.service.js
+++ b/src/services/finance.service.js
@@ -14,6 +14,9 @@ const CSV_COLUMNS = [
 
 const MONTH_LABELS = ['Jan', 'Fev', 'Mar', 'Abr', 'Mai', 'Jun', 'Jul', 'Ago', 'Set', 'Out', 'Nov', 'Dez'];
 
+const REVENUE_TYPES = ['session_revenue'];
+const PENALTY_TYPES = ['no_show_fee', 'cancellation_fee'];
+
 function createFinanceService(prismaClient) {
   async function _resolveStudentAccountId(studentNumber) {
     if (!studentNumber) return null;
@@ -142,8 +145,8 @@ function createFinanceService(prismaClient) {
       totalEntries += count;
       exportedCount += exported;
       unexportedCount += unexported;
-      if (row.typeName === 'SESSION') totalRevenue += total;
-      else totalPenalties += total;
+      if (REVENUE_TYPES.includes(row.typeName)) totalRevenue += total;
+      else if (PENALTY_TYPES.includes(row.typeName)) totalPenalties += total;
     }
 
     return {
@@ -169,12 +172,15 @@ function createFinanceService(prismaClient) {
       );
     }
 
+    const revenueTypes = Prisma.join(REVENUE_TYPES);
+    const penaltyTypes = Prisma.join(PENALTY_TYPES);
+
     const rows = await prismaClient.$queryRaw(Prisma.sql`
       SELECT
         MONTH(fe.CreatedAt) AS month,
-        CAST(SUM(CASE WHEN fet.TypeName = 'SESSION' THEN fe.Amount ELSE 0 END) AS DECIMAL(18,2)) AS revenue,
-        CAST(SUM(CASE WHEN fet.TypeName IN ('NOSHOWPENALTY', 'CANCELLATIONFEE') THEN fe.Amount ELSE 0 END) AS DECIMAL(18,2)) AS penalties,
-        COUNT(CASE WHEN fet.TypeName = 'SESSION' THEN 1 ELSE NULL END) AS sessionCount
+        CAST(SUM(CASE WHEN fet.TypeName IN (${revenueTypes}) THEN fe.Amount ELSE 0 END) AS DECIMAL(18,2)) AS revenue,
+        CAST(SUM(CASE WHEN fet.TypeName IN (${penaltyTypes}) THEN fe.Amount ELSE 0 END) AS DECIMAL(18,2)) AS penalties,
+        COUNT(CASE WHEN fet.TypeName IN (${revenueTypes}) THEN 1 ELSE NULL END) AS sessionCount
       FROM FinancialEntry fe
       INNER JOIN FinancialEntryType fet ON fet.EntryTypeID = fe.EntryTypeID
       WHERE ${Prisma.join(conditions, ' AND ')}

--- a/src/services/pricing.service.js
+++ b/src/services/pricing.service.js
@@ -62,9 +62,9 @@ function createPricingService(prismaClient) {
       const finalPrice = await calculateFinalPrice(sessionId, tx);
 
       const entryType = await tx.financialEntryType.findUnique({
-        where: { TypeName: 'NOSHOWPENALTY' },
+        where: { TypeName: 'no_show_fee' },
       });
-      if (!entryType) throw new Error("FinancialEntryType 'NOSHOWPENALTY' not found");
+      if (!entryType) throw new Error("FinancialEntryType 'no_show_fee' not found");
 
       const summary = await _findOrCreateMonthSummary(tx, userId);
 
@@ -100,9 +100,9 @@ function createPricingService(prismaClient) {
       const finalPrice = await calculateFinalPrice(sessionId, db);
 
       const entryType = await db.financialEntryType.findUnique({
-        where: { TypeName: 'SESSION' },
+        where: { TypeName: 'session_revenue' },
       });
-      if (!entryType) throw new Error("FinancialEntryType 'SESSION' not found");
+      if (!entryType) throw new Error("FinancialEntryType 'session_revenue' not found");
 
       const summary = await _findOrCreateMonthSummary(db, userId);
 

--- a/test/unit/finance.service.test.js
+++ b/test/unit/finance.service.test.js
@@ -2,7 +2,7 @@ const test = require('node:test');
 const assert = require('node:assert/strict');
 const { createFinanceService } = require('../../src/services/finance.service');
 
-const FAKE_ENTRY_TYPE = { EntryTypeID: 1, TypeName: 'SESSION' };
+const FAKE_ENTRY_TYPE = { EntryTypeID: 1, TypeName: 'session_revenue' };
 const FAKE_USER = { UserID: 5, FirstName: 'Ana', LastName: 'Silva', AuthUID: 'ST-0001' };
 const FAKE_STUDENT_ACCOUNT = { StudentAccountID: 3, User: FAKE_USER };
 const FAKE_SESSION_STUDENT = { StudentAccountID: 3, StudentAccount: FAKE_STUDENT_ACCOUNT };
@@ -64,7 +64,7 @@ test('listTransactions: maps entries to expected shape', async () => {
   assert.equal(item.entryId, 1);
   assert.equal(item.sessionId, 10);
   assert.equal(item.amount, 36);
-  assert.equal(item.entryType, 'SESSION');
+  assert.equal(item.entryType, 'session_revenue');
   assert.equal(item.isExported, false);
   assert.equal(item.studentName, 'Ana Silva');
   assert.equal(item.studentNumber, 'ST-0001');
@@ -101,8 +101,8 @@ test('listTransactions: resolves studentNumber to studentAccountId via DB lookup
 
 test('getSummary: aggregates rows correctly', async () => {
   const rawRows = [
-    { typeName: 'SESSION', cnt: BigInt(3), total: 108.0, exportedCount: BigInt(2), unexportedCount: BigInt(1) },
-    { typeName: 'NOSHOWPENALTY', cnt: BigInt(1), total: 36.0, exportedCount: BigInt(0), unexportedCount: BigInt(1) },
+    { typeName: 'session_revenue', cnt: BigInt(3), total: 108.0, exportedCount: BigInt(2), unexportedCount: BigInt(1) },
+    { typeName: 'no_show_fee', cnt: BigInt(1), total: 36.0, exportedCount: BigInt(0), unexportedCount: BigInt(1) },
   ];
   const svc = createFinanceService(makeFakePrisma({ rawRows }));
   const result = await svc.getSummary({});
@@ -111,9 +111,9 @@ test('getSummary: aggregates rows correctly', async () => {
   assert.equal(result.totalPenalties, 36);
   assert.equal(result.exportedCount, 2);
   assert.equal(result.unexportedCount, 2);
-  assert.equal(result.totalsByType.SESSION.count, 3);
-  assert.equal(result.totalsByType.SESSION.total, 108);
-  assert.equal(result.totalsByType.NOSHOWPENALTY.count, 1);
+  assert.equal(result.totalsByType.session_revenue.count, 3);
+  assert.equal(result.totalsByType.session_revenue.total, 108);
+  assert.equal(result.totalsByType.no_show_fee.count, 1);
 });
 
 test('getSummary: returns zero totals when no data', async () => {
@@ -164,7 +164,7 @@ test('exportTransactions: marks entries as exported and returns CSV', async () =
   }));
   const result = await svc.exportTransactions({ periodStart: new Date('2026-04-01'), periodEnd: new Date('2026-04-30'), userId: 99 });
   assert.equal(result.count, 1);
-  assert.ok(result.csv.includes('SESSION'));
+  assert.ok(result.csv.includes('session_revenue'));
   assert.ok(result.csv.includes('Ana Silva'));
   assert.equal(capturedUpdate.IsExported, true);
   assert.equal(capturedUpdate.ExportedByUserID, 99);

--- a/test/unit/pricing.service.test.js
+++ b/test/unit/pricing.service.test.js
@@ -4,8 +4,8 @@ const { createPricingService } = require('../../src/services/pricing.service');
 
 const FAKE_SUMMARY = { FinancialSummaryID: 1 };
 const FAKE_YEAR = { AcademicYearID: 1 };
-const FAKE_SESSION_TYPE = { EntryTypeID: 2, TypeName: 'SESSION' };
-const FAKE_NOSHOWPENALTY_TYPE = { EntryTypeID: 3, TypeName: 'NOSHOWPENALTY' };
+const FAKE_SESSION_TYPE = { EntryTypeID: 2, TypeName: 'session_revenue' };
+const FAKE_NOSHOWPENALTY_TYPE = { EntryTypeID: 3, TypeName: 'no_show_fee' };
 
 function makeSession({ hourlyRate = 36, durationMs = 3_600_000, isOutside = false, isExternal = false } = {}) {
   const start = new Date('2026-04-18T10:00:00Z');
@@ -23,8 +23,8 @@ function makeFakePrisma(session, { entryCreateThrows = false, summaryExists = tr
   const fakeTx = {
     financialEntryType: {
       findUnique: async ({ where }) => {
-        if (where.TypeName === 'SESSION') return FAKE_SESSION_TYPE;
-        if (where.TypeName === 'NOSHOWPENALTY') return FAKE_NOSHOWPENALTY_TYPE;
+        if (where.TypeName === 'session_revenue') return FAKE_SESSION_TYPE;
+        if (where.TypeName === 'no_show_fee') return FAKE_NOSHOWPENALTY_TYPE;
         return null;
       },
     },


### PR DESCRIPTION
The FinancialEntryType seeded in the DB uses snake_case TypeNames
(session_revenue, no_show_fee, inventory_fee, marketplace_fee), but
the code was querying the legacy uppercase values (SESSION,
NOSHOWPENALTY, CANCELLATIONFEE).

This caused:
- /admin/finance/summary returning totalRevenue=0 and an inflated
  totalPenalties (any non-SESSION row fell into the else branch).
- /admin/finance/revenue returning all-zero monthly buckets.
- /admin/finance/transactions?entryType=... rejecting every real value
  via the express-validator schema.
- pricing.service throwing "FinancialEntryType '...' not found" when
  finalising sessions or applying no-show penalties.
- adminDashboard.getMonthlyRevenue and admin.assertNoFinalFinancialEntry
  silently returning wrong data.

Changes:
- finance.service.js: extract REVENUE_TYPES / PENALTY_TYPES, use
  Prisma.join in the raw SQL aggregations; inventory_fee and
  marketplace_fee surface in totalsByType but no longer inflate
  totalPenalties.
- finance.schema.js: KNOWN_ENTRY_TYPES updated to match seeded values.
- pricing.service.js, admin.service.js, adminDashboard.service.js:
  same casing alignment.
- finance/pricing unit tests updated to use the new fixtures.

Closes #39 (post-merge fix).
