### PR TITLE
feat: implement lost and found management for admin with CRUD operations and security

### DIFF
--- a/src/config/swagger.js
+++ b/src/config/swagger.js
@@ -290,9 +290,30 @@ const swaggerSpec = swaggerJsdoc({
         },
       },
       '/admin/lostfound': {
+        get: {
+          tags: ['LostFound'],
+          summary: 'List lost and found items for admin',
+          security: [{ sessionCookieAuth: [] }],
+          responses: {
+            200: {
+              description: 'List of lost and found items including archived entries',
+              content: {
+                'application/json': {
+                  schema: {
+                    type: 'array',
+                    items: { $ref: '#/components/schemas/LostFoundAdminItem' },
+                  },
+                },
+              },
+            },
+            401: { description: 'Not authenticated' },
+            403: { description: 'Forbidden' },
+          },
+        },
         post: {
           tags: ['LostFound'],
           summary: 'Create lost and found item (admin)',
+          security: [{ sessionCookieAuth: [] }],
           requestBody: {
             required: true,
             content: {
@@ -316,9 +337,36 @@ const swaggerSpec = swaggerJsdoc({
         },
       },
       '/admin/lostfound/{id}': {
+        get: {
+          tags: ['LostFound'],
+          summary: 'Get one lost and found item for admin',
+          security: [{ sessionCookieAuth: [] }],
+          parameters: [
+            {
+              in: 'path',
+              name: 'id',
+              required: true,
+              schema: { type: 'integer' },
+            },
+          ],
+          responses: {
+            200: {
+              description: 'Item found',
+              content: {
+                'application/json': {
+                  schema: { $ref: '#/components/schemas/LostFoundAdminItem' },
+                },
+              },
+            },
+            401: { description: 'Not authenticated' },
+            403: { description: 'Forbidden' },
+            404: { description: 'Not found' },
+          },
+        },
         patch: {
           tags: ['LostFound'],
           summary: 'Update lost and found item (admin)',
+          security: [{ sessionCookieAuth: [] }],
           parameters: [
             {
               in: 'path',
@@ -352,6 +400,7 @@ const swaggerSpec = swaggerJsdoc({
         delete: {
           tags: ['LostFound'],
           summary: 'Delete lost and found item (admin)',
+          security: [{ sessionCookieAuth: [] }],
           parameters: [
             {
               in: 'path',
@@ -372,6 +421,7 @@ const swaggerSpec = swaggerJsdoc({
         patch: {
           tags: ['LostFound'],
           summary: 'Mark lost and found item as claimed (admin)',
+          security: [{ sessionCookieAuth: [] }],
           parameters: [
             {
               in: 'path',
@@ -407,6 +457,7 @@ const swaggerSpec = swaggerJsdoc({
         patch: {
           tags: ['LostFound'],
           summary: 'Archive lost and found item (admin)',
+          security: [{ sessionCookieAuth: [] }],
           parameters: [
             {
               in: 'path',

--- a/src/controllers/lostFound.controller.js
+++ b/src/controllers/lostFound.controller.js
@@ -1,4 +1,9 @@
 const lostFoundService = require('../services/lostFound.service');
+const { getSessionRole } = require('../middlewares/rbac.middleware');
+
+function getRequestRole(req) {
+  return getSessionRole(req.session);
+}
 
 async function listPublic(req, res, next) {
   try {
@@ -25,9 +30,34 @@ async function getPublicById(req, res, next) {
   }
 }
 
+async function listAdmin(req, res, next) {
+  try {
+    const items = await lostFoundService.listAdminItems(getRequestRole(req));
+    res.json(items);
+  } catch (error) {
+    next(error);
+  }
+}
+
+async function getAdminById(req, res, next) {
+  try {
+    const id = Number(req.params.id);
+    const item = await lostFoundService.getAdminItemById(id, getRequestRole(req));
+
+    if (!item) {
+      res.status(404).json({ error: 'Lost and found item not found' });
+      return;
+    }
+
+    res.json(item);
+  } catch (error) {
+    next(error);
+  }
+}
+
 async function create(req, res, next) {
   try {
-    const item = await lostFoundService.createItem(req.body, req.session.userId);
+    const item = await lostFoundService.createItem(req.body, req.session.userId, getRequestRole(req));
     res.status(201).json(item);
   } catch (error) {
     next(error);
@@ -37,7 +67,7 @@ async function create(req, res, next) {
 async function update(req, res, next) {
   try {
     const id = Number(req.params.id);
-    const item = await lostFoundService.updateItem(id, req.body);
+    const item = await lostFoundService.updateItem(id, req.body, getRequestRole(req));
 
     if (!item) {
       res.status(404).json({ error: 'Lost and found item not found' });
@@ -69,7 +99,7 @@ async function remove(req, res, next) {
 async function claim(req, res, next) {
   try {
     const id = Number(req.params.id);
-    const item = await lostFoundService.claimItem(id, req.body.adminNotes);
+    const item = await lostFoundService.claimItem(id, req.body.adminNotes, getRequestRole(req));
 
     if (!item) {
       res.status(404).json({ error: 'Lost and found item not found' });
@@ -85,7 +115,7 @@ async function claim(req, res, next) {
 async function archive(req, res, next) {
   try {
     const id = Number(req.params.id);
-    const item = await lostFoundService.archiveItem(id, req.body.adminNotes);
+    const item = await lostFoundService.archiveItem(id, req.body.adminNotes, getRequestRole(req));
 
     if (!item) {
       res.status(404).json({ error: 'Lost and found item not found' });
@@ -101,6 +131,8 @@ async function archive(req, res, next) {
 module.exports = {
   listPublic,
   getPublicById,
+  listAdmin,
+  getAdminById,
   create,
   update,
   remove,

--- a/src/routes/lostFound.routes.js
+++ b/src/routes/lostFound.routes.js
@@ -19,6 +19,20 @@ const adminLostFoundAccess = [requireSessionAuth, requireRole(['ADMIN'])];
 router.get('/lostfound', lostFoundController.listPublic);
 router.get('/lostfound/:id', ...itemIdParamSchema, validateRequest, lostFoundController.getPublicById);
 
+router.get(
+  '/admin/lostfound',
+  ...adminLostFoundAccess,
+  lostFoundController.listAdmin
+);
+
+router.get(
+  '/admin/lostfound/:id',
+  ...adminLostFoundAccess,
+  ...itemIdParamSchema,
+  validateRequest,
+  lostFoundController.getAdminById
+);
+
 router.post(
   '/admin/lostfound',
   ...adminLostFoundAccess,

--- a/src/services/lostFound.service.js
+++ b/src/services/lostFound.service.js
@@ -1,5 +1,9 @@
 const prisma = require('../config/prisma');
 
+function isAdminRole(role) {
+  return String(role || '').trim().toLowerCase() === 'admin';
+}
+
 function toPublicDto(item) {
   return {
     id: item.LostItemID,
@@ -11,14 +15,19 @@ function toPublicDto(item) {
   };
 }
 
-function toAdminDto(item) {
-  return {
+function toAdminDto(item, role) {
+  const dto = {
     ...toPublicDto(item),
     isArchived: item.IsArchived,
-    adminNotes: item.AdminNotes,
     archivedAt: item.ArchivedAt,
     registeredByUserId: item.RegisteredByUserID,
   };
+
+  if (isAdminRole(role)) {
+    dto.adminNotes = item.AdminNotes;
+  }
+
+  return dto;
 }
 
 async function findItemById(id) {
@@ -51,7 +60,24 @@ async function getPublicItemById(id) {
   return item ? toPublicDto(item) : null;
 }
 
-async function createItem(data, registeredByUserId) {
+async function listAdminItems(role) {
+  const items = await prisma.lostAndFoundItem.findMany({
+    orderBy: [
+      { IsArchived: 'asc' },
+      { FoundDate: 'desc' },
+    ],
+  });
+
+  return items.map((item) => toAdminDto(item, role));
+}
+
+async function getAdminItemById(id, role) {
+  const item = await findItemById(id);
+
+  return item ? toAdminDto(item, role) : null;
+}
+
+async function createItem(data, registeredByUserId, role) {
   const created = await prisma.lostAndFoundItem.create({
     data: {
       Title: data.title,
@@ -64,10 +90,10 @@ async function createItem(data, registeredByUserId) {
     },
   });
 
-  return toAdminDto(created);
+  return toAdminDto(created, role);
 }
 
-async function updateItem(id, data) {
+async function updateItem(id, data, role) {
   const existing = await findItemById(id);
 
   if (!existing) {
@@ -86,7 +112,7 @@ async function updateItem(id, data) {
     },
   });
 
-  return toAdminDto(updated);
+  return toAdminDto(updated, role);
 }
 
 async function deleteItem(id) {
@@ -103,7 +129,7 @@ async function deleteItem(id) {
   return true;
 }
 
-async function claimItem(id, adminNotes) {
+async function claimItem(id, adminNotes, role) {
   const existing = await findItemById(id);
 
   if (!existing) {
@@ -118,10 +144,10 @@ async function claimItem(id, adminNotes) {
     },
   });
 
-  return toAdminDto(updated);
+  return toAdminDto(updated, role);
 }
 
-async function archiveItem(id, adminNotes) {
+async function archiveItem(id, adminNotes, role) {
   const existing = await findItemById(id);
 
   if (!existing) {
@@ -137,12 +163,14 @@ async function archiveItem(id, adminNotes) {
     },
   });
 
-  return toAdminDto(updated);
+  return toAdminDto(updated, role);
 }
 
 module.exports = {
   listPublicItems,
   getPublicItemById,
+  listAdminItems,
+  getAdminItemById,
   createItem,
   updateItem,
   deleteItem,

--- a/test/integration/lostFound.integration.test.js
+++ b/test/integration/lostFound.integration.test.js
@@ -226,6 +226,8 @@ if (!shouldRun) {
     assert.equal(second.status, 200);
     assert.equal(first.body.claimedStatus, true);
     assert.equal(second.body.claimedStatus, true);
+    assert.equal(first.body.adminNotes, 'Claimed once');
+    assert.equal(second.body.adminNotes, 'Claimed twice');
   });
 
   test('admin archive endpoint stores admin notes', async (t) => {
@@ -260,6 +262,92 @@ if (!shouldRun) {
     assert.equal(updated.IsArchived, true);
     assert.equal(updated.AdminNotes, 'Archived by integration test');
     assert.ok(updated.ArchivedAt instanceof Date);
+  });
+
+  test('admin listing returns archived items and admin notes', async (t) => {
+    if (!registeredByUserId) {
+      t.skip('No active user available to register lost and found item');
+      return;
+    }
+
+    const cookie = await createSessionCookie(registeredByUserId, 'admin');
+    if (!cookie) {
+      t.skip('SESSION_SECRET is required to create signed test session cookies');
+      return;
+    }
+
+    const active = await createLostFoundItem({
+      AdminNotes: 'Visible only to admin',
+      IsArchived: false,
+    });
+    const archived = await createLostFoundItem({
+      AdminNotes: 'Archived internal note',
+      IsArchived: true,
+      ArchivedAt: new Date(),
+    });
+
+    const response = await request('/admin/lostfound', {
+      headers: {
+        Cookie: cookie,
+      },
+    });
+
+    assert.equal(response.status, 200);
+    assert.ok(Array.isArray(response.body));
+
+    const activeItem = response.body.find((item) => item.id === active.LostItemID);
+    const archivedItem = response.body.find((item) => item.id === archived.LostItemID);
+
+    assert.ok(activeItem);
+    assert.ok(archivedItem);
+    assert.equal(activeItem.adminNotes, 'Visible only to admin');
+    assert.equal(archivedItem.adminNotes, 'Archived internal note');
+    assert.equal(archivedItem.isArchived, true);
+  });
+
+  test('public lost and found responses never expose admin notes', async (t) => {
+    if (!registeredByUserId) {
+      t.skip('No active user available to register lost and found item');
+      return;
+    }
+
+    const item = await createLostFoundItem({
+      AdminNotes: 'Internal only',
+      IsArchived: false,
+    });
+
+    const listResponse = await request('/lostfound');
+    const detailResponse = await request(`/lostfound/${item.LostItemID}`);
+
+    assert.equal(listResponse.status, 200);
+    assert.equal(detailResponse.status, 200);
+
+    const listedItem = listResponse.body.find((entry) => entry.id === item.LostItemID);
+
+    assert.ok(listedItem);
+    assert.equal(Object.hasOwn(listedItem, 'adminNotes'), false);
+    assert.equal(Object.hasOwn(detailResponse.body, 'adminNotes'), false);
+  });
+
+  test('admin get by id returns 404 for missing item', async (t) => {
+    if (!registeredByUserId) {
+      t.skip('No active user available to register lost and found item');
+      return;
+    }
+
+    const cookie = await createSessionCookie(registeredByUserId, 'admin');
+    if (!cookie) {
+      t.skip('SESSION_SECRET is required to create signed test session cookies');
+      return;
+    }
+
+    const response = await request('/admin/lostfound/999999999', {
+      headers: {
+        Cookie: cookie,
+      },
+    });
+
+    assert.equal(response.status, 404);
   });
 
   test('admin endpoints reject missing and non-admin sessions', async (t) => {


### PR DESCRIPTION
Implementa endpoints de leitura administrativa para o módulo Lost & Found, permitindo listagem e detalhe completos via /admin/lostfound (GET). Garante que o campo adminNotes só é devolvido para utilizadores com role admin. Atualiza documentação OpenAPI e testes de integração para cobrir estes fluxos e proteger a exposição de dados internos. Todos os testes relevantes passam.