### PR TITLE
Implement session confirmation and no-show registration features in teacher routes and controller

### DIFF
--- a/server/tests/helpers/createTestApp.js
+++ b/server/tests/helpers/createTestApp.js
@@ -18,6 +18,7 @@ function createTestApp({
   bcryptMock,
   joinRequestServiceMock,
   notificationControllerMock,
+  pricingServiceMock,
 } = {}) {
   jest.resetModules();
 
@@ -59,6 +60,10 @@ function createTestApp({
 
   if (notificationControllerMock) {
     jest.doMock('../../../src/controllers/notification.controller', () => notificationControllerMock);
+  }
+
+  if (pricingServiceMock) {
+    jest.doMock('../../../src/services/pricing.service', () => pricingServiceMock);
   }
 
   const app = require('../../../src/app');

--- a/server/tests/session-confirmation.test.js
+++ b/server/tests/session-confirmation.test.js
@@ -1,0 +1,571 @@
+/**
+ * Session Confirmation Tracking — Integration Tests (BR-14 / BR-16)
+ *
+ * Covers:
+ *   GET  /teacher/sessions/pending
+ *   PATCH /teacher/sessions/:id/confirm-completion
+ *   POST  /teacher/sessions/:id/no-show
+ */
+
+const request = require('supertest');
+
+const { createTestApp } = require('./helpers/createTestApp');
+const { buildLoginPayload, buildUser } = require('./fixtures/auth.fixtures');
+
+// ---------------------------------------------------------------------------
+// Fixtures
+// ---------------------------------------------------------------------------
+
+const PAST_TIME = new Date('2026-04-20T10:00:00.000Z');
+const FUTURE_TIME = new Date('2099-01-01T12:00:00.000Z');
+
+/** Builds a CoachingSession row as Prisma would return it from findFirst/findMany */
+function buildSession({
+  sessionId = 1,
+  statusName = 'Scheduled',
+  endTime = PAST_TIME,
+  validations = [],
+  students = [],
+  reviewNotes = null,
+} = {}) {
+  return {
+    SessionID: sessionId,
+    StartTime: new Date(endTime.getTime() - 3_600_000),
+    EndTime: endTime,
+    ReviewNotes: reviewNotes,
+    StatusID: 1,
+    SessionStatus: { StatusID: 1, StatusName: statusName },
+    Studio: { StudioName: 'Sala A' },
+    Modality: { ModalityName: 'Ballet' },
+    SessionValidation: validations,
+    SessionStudent: students,
+    ValidationRequestedAt: null,
+  };
+}
+
+function buildEnrollment({
+  studentAccountId = 10,
+  userId = 20,
+  firstName = 'Ana',
+  lastName = 'Silva',
+  email = 'ana@example.com',
+  attendanceStatus = 'Pending',
+} = {}) {
+  return {
+    StudentAccountID: studentAccountId,
+    AttendanceStatusID: 1,
+    AttendanceStatus: { StatusName: attendanceStatus },
+    StudentAccount: {
+      User: { UserID: userId, FirstName: firstName, LastName: lastName, Email: email },
+    },
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Context factory — one per test (jest.resetModules inside createTestApp)
+// ---------------------------------------------------------------------------
+
+function createContext() {
+  const teacherUser = buildUser({ userId: 5, email: 'teacher@example.com', role: 'teacher' });
+  const studentUser = buildUser({ userId: 20, email: 'student@example.com', role: 'student' });
+  const adminUser   = buildUser({ userId: 99, email: 'admin@example.com',   role: 'admin'   });
+
+  const usersByEmail = new Map([teacherUser, studentUser, adminUser].map((u) => [u.Email, u]));
+  const usersById    = new Map([teacherUser, studentUser, adminUser].map((u) => [u.UserID, u]));
+
+  // Mutable per-test state
+  const db = {
+    // coachingSession.findMany  (getPendingSessions)
+    sessionRows: [],
+    // coachingSession.findFirst (confirmCompletion / registerNoShow)
+    sessionRow: null,
+    // sessionStatus.findMany
+    sessionStatuses: [{ StatusID: 7, StatusName: 'FINALIZATION_VALIDATION_PENDING' }],
+    // attendanceStatus.findMany
+    attendanceStatuses: [{ AttendanceStatusID: 3, StatusName: 'NO_SHOW' }],
+    // validationStep.findMany
+    validationSteps: [
+      { StepID: 2, StepName: 'TeacherConfirmation' },
+      { StepID: 3, StepName: 'NoShowRecorded'      },
+    ],
+    // userRole.findMany — admins for notifications
+    adminUserRoleRows: [{ UserID: adminUser.UserID }],
+    // financialEntry.findFirst — return null to trigger penalty creation
+    existingPenalty: null,
+    // captured calls
+    sessionUpdates:           [],
+    validationCreated:        null,
+    attendanceUpdate:         null,
+    notificationsCreated:     [],
+    noShowPenaltyApplied:     false,
+  };
+
+  const prismaMock = {
+    user: {
+      findUnique: jest.fn(async ({ where }) => {
+        if (where?.Email)  return usersByEmail.get(String(where.Email).toLowerCase()) ?? null;
+        if (where?.UserID) return usersById.get(Number(where.UserID)) ?? null;
+        return null;
+      }),
+    },
+
+    // getPendingSessions queries coachingSession.findMany directly
+    coachingSession: {
+      findMany: jest.fn(async () => db.sessionRows),
+      findFirst: jest.fn(async () => db.sessionRow),
+      update: jest.fn(async ({ data }) => {
+        db.sessionUpdates.push(data);
+        return {};
+      }),
+    },
+
+    // resolveOrCreateSessionStatusId uses findMany
+    sessionStatus: {
+      findMany: jest.fn(async () => db.sessionStatuses),
+      create: jest.fn(async ({ data }) => ({ StatusID: 99, ...data })),
+    },
+
+    // resolveOrCreateAttendanceStatusId uses findMany
+    attendanceStatus: {
+      findMany: jest.fn(async () => db.attendanceStatuses),
+      create: jest.fn(async ({ data }) => ({ AttendanceStatusID: 98, ...data })),
+    },
+
+    // getOrCreateValidationStep uses findMany with select
+    validationStep: {
+      findMany: jest.fn(async () => db.validationSteps),
+      create: jest.fn(async ({ data }) => ({ StepID: 97, ...data })),
+    },
+
+    sessionValidation: {
+      create: jest.fn(async ({ data }) => {
+        db.validationCreated = data;
+        return { ValidationID: 500, ValidatedAt: new Date(), ...data };
+      }),
+    },
+
+    sessionStudent: {
+      update: jest.fn(async ({ data }) => {
+        db.attendanceUpdate = data;
+        return {};
+      }),
+    },
+
+    // listAdminUserIds uses userRole.findMany with role filter
+    userRole: {
+      findMany: jest.fn(async () => db.adminUserRoleRows),
+    },
+
+    notification: {
+      create: jest.fn(async ({ data }) => {
+        db.notificationsCreated.push(data);
+        return { NotificationID: Math.random(), ...data };
+      }),
+      createMany: jest.fn(async ({ data }) => {
+        (Array.isArray(data) ? data : [data]).forEach((n) => db.notificationsCreated.push(n));
+        return { count: Array.isArray(data) ? data.length : 1 };
+      }),
+    },
+
+    financialEntry: {
+      findFirst: jest.fn(async () => db.existingPenalty),
+    },
+
+    $transaction: jest.fn(async (fn) => fn(prismaMock)),
+  };
+
+  const bcryptMock = { compare: jest.fn(async () => true) };
+
+  const notificationControllerMock = {
+    getAll:              jest.fn((_req, res) => res.status(501).end()),
+    getById:             jest.fn((_req, res) => res.status(501).end()),
+    markAsRead:          jest.fn((_req, res) => res.status(501).end()),
+    remove:              jest.fn((_req, res) => res.status(501).end()),
+    create:              jest.fn((_req, res) => res.status(501).end()),
+    broadcastNotification: jest.fn((_req, res) => res.status(501).end()),
+    sendNotification:    jest.fn(async () => ({ notificationId: 1 })),
+  };
+
+  // pricingService is instantiated at controller load time via createPricingService(prisma)
+  const pricingServiceMock = {
+    createPricingService: jest.fn(() => ({
+      applyNoShowPenalty: jest.fn(async () => {
+        db.noShowPenaltyApplied = true;
+        return { EntryID: 900 };
+      }),
+    })),
+  };
+
+  const { app } = createTestApp({
+    prismaMock,
+    bcryptMock,
+    notificationControllerMock,
+    pricingServiceMock,
+  });
+
+  return { app, teacherUser, studentUser, db, prismaMock };
+}
+
+async function loginAs(agent, user) {
+  const res = await agent.post('/auth/login').send(buildLoginPayload(user.Email));
+  expect(res.status).toBe(200);
+}
+
+// ---------------------------------------------------------------------------
+// GET /teacher/sessions/pending
+// ---------------------------------------------------------------------------
+
+describe('GET /teacher/sessions/pending', () => {
+  test('returns 401 when unauthenticated', async () => {
+    const { app } = createContext();
+    const res = await request(app).get('/teacher/sessions/pending');
+    expect(res.status).toBe(401);
+  });
+
+  test('returns 403 for student role', async () => {
+    const { app, studentUser } = createContext();
+    const agent = request.agent(app);
+    await loginAs(agent, studentUser);
+
+    const res = await agent.get('/teacher/sessions/pending');
+    expect(res.status).toBe(403);
+  });
+
+  test('returns empty list when no sessions exist', async () => {
+    const { app, teacherUser, db } = createContext();
+    db.sessionRows = [];
+
+    const agent = request.agent(app);
+    await loginAs(agent, teacherUser);
+
+    const res = await agent.get('/teacher/sessions/pending');
+    expect(res.status).toBe(200);
+    expect(res.body.sessions).toEqual([]);
+    expect(res.body.summary.pendingCount).toBe(0);
+  });
+
+  test('returns pending sessions with mapped student list', async () => {
+    const { app, teacherUser, db } = createContext();
+    db.sessionRows = [
+      buildSession({
+        sessionId: 42,
+        students: [buildEnrollment({ studentAccountId: 10, userId: 20, firstName: 'Ana', lastName: 'Silva' })],
+      }),
+    ];
+
+    const agent = request.agent(app);
+    await loginAs(agent, teacherUser);
+
+    const res = await agent.get('/teacher/sessions/pending');
+    expect(res.status).toBe(200);
+    expect(res.body.summary.pendingCount).toBe(1);
+
+    const session = res.body.sessions[0];
+    expect(session.sessionId).toBe(42);
+    expect(session.studioName).toBe('Sala A');
+    expect(session.modalityName).toBe('Ballet');
+    expect(session.students).toHaveLength(1);
+    expect(session.students[0].studentName).toBe('Ana Silva');
+    expect(session.students[0].studentEmail).toBe('ana@example.com');
+    expect(session.students[0].canRegisterNoShow).toBe(true);
+  });
+
+  test('excludes sessions with terminal status (cancelled)', async () => {
+    const { app, teacherUser, db } = createContext();
+    db.sessionRows = [buildSession({ sessionId: 1, statusName: 'Cancelled' })];
+
+    const agent = request.agent(app);
+    await loginAs(agent, teacherUser);
+
+    const res = await agent.get('/teacher/sessions/pending');
+    expect(res.status).toBe(200);
+    expect(res.body.sessions).toHaveLength(0);
+  });
+
+  test('marks teacherConfirmed=true when teacher already confirmed', async () => {
+    const { app, teacherUser, db } = createContext();
+    db.sessionRows = [
+      buildSession({
+        sessionId: 1,
+        validations: [
+          {
+            ValidatedByUserID: teacherUser.UserID,
+            ValidationStep: { StepName: 'TeacherConfirmation' },
+          },
+        ],
+      }),
+    ];
+
+    const agent = request.agent(app);
+    await loginAs(agent, teacherUser);
+
+    const res = await agent.get('/teacher/sessions/pending');
+    expect(res.status).toBe(200);
+    // Session still appears (not filtered out) but teacherConfirmed=true, canConfirmCompletion=false
+    expect(res.body.sessions[0].teacherConfirmed).toBe(true);
+    expect(res.body.sessions[0].canConfirmCompletion).toBe(false);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// PATCH /teacher/sessions/:id/confirm-completion
+// ---------------------------------------------------------------------------
+
+describe('PATCH /teacher/sessions/:id/confirm-completion', () => {
+  test('returns 401 when unauthenticated', async () => {
+    const { app } = createContext();
+    const res = await request(app).patch('/teacher/sessions/1/confirm-completion');
+    expect(res.status).toBe(401);
+  });
+
+  test('returns 403 for student role', async () => {
+    const { app, studentUser } = createContext();
+    const agent = request.agent(app);
+    await loginAs(agent, studentUser);
+
+    const res = await agent.patch('/teacher/sessions/1/confirm-completion');
+    expect(res.status).toBe(403);
+  });
+
+  test('returns 400 for non-numeric session id', async () => {
+    const { app, teacherUser } = createContext();
+    const agent = request.agent(app);
+    await loginAs(agent, teacherUser);
+
+    const res = await agent.patch('/teacher/sessions/abc/confirm-completion');
+    expect(res.status).toBe(400);
+  });
+
+  test('returns 404 when session not found or teacher not assigned', async () => {
+    const { app, teacherUser, db } = createContext();
+    db.sessionRow = null;
+    const agent = request.agent(app);
+    await loginAs(agent, teacherUser);
+
+    const res = await agent.patch('/teacher/sessions/99/confirm-completion');
+    expect(res.status).toBe(404);
+  });
+
+  test('returns 409 when session has not ended yet', async () => {
+    const { app, teacherUser, db } = createContext();
+    db.sessionRow = buildSession({ sessionId: 1, endTime: FUTURE_TIME });
+    const agent = request.agent(app);
+    await loginAs(agent, teacherUser);
+
+    const res = await agent.patch('/teacher/sessions/1/confirm-completion');
+    expect(res.status).toBe(409);
+    expect(res.body.error).toMatch(/has not ended yet/i);
+  });
+
+  test('returns 409 when session is in a terminal state', async () => {
+    const { app, teacherUser, db } = createContext();
+    db.sessionRow = buildSession({ sessionId: 1, statusName: 'Cancelled', endTime: PAST_TIME });
+    const agent = request.agent(app);
+    await loginAs(agent, teacherUser);
+
+    const res = await agent.patch('/teacher/sessions/1/confirm-completion');
+    expect(res.status).toBe(409);
+    expect(res.body.error).toMatch(/not eligible/i);
+  });
+
+  test('returns 409 when teacher already confirmed this session', async () => {
+    const { app, teacherUser, db } = createContext();
+    db.sessionRow = buildSession({
+      sessionId: 1,
+      endTime: PAST_TIME,
+      validations: [
+        {
+          ValidatedByUserID: teacherUser.UserID,
+          ValidationStep: { StepName: 'TeacherConfirmation' },
+        },
+      ],
+    });
+    const agent = request.agent(app);
+    await loginAs(agent, teacherUser);
+
+    const res = await agent.patch('/teacher/sessions/1/confirm-completion');
+    expect(res.status).toBe(409);
+    expect(res.body.error).toMatch(/already confirmed/i);
+  });
+
+  test('records TeacherConfirmation and updates session status — BR-14', async () => {
+    const { app, teacherUser, db, prismaMock } = createContext();
+    db.sessionRow = buildSession({ sessionId: 1, endTime: PAST_TIME });
+
+    const agent = request.agent(app);
+    await loginAs(agent, teacherUser);
+
+    const res = await agent.patch('/teacher/sessions/1/confirm-completion');
+    expect(res.status).toBe(201);
+    expect(res.body.sessionId).toBe(1);
+    expect(res.body.validationId).toBeDefined();
+    expect(res.body.validatedAt).toBeDefined();
+
+    // Validation record created with teacher's user id
+    expect(db.validationCreated).toMatchObject({
+      SessionID: 1,
+      ValidatedByUserID: teacherUser.UserID,
+    });
+
+    // Session status updated to FINALIZATION_VALIDATION_PENDING (StatusID 7)
+    expect(prismaMock.coachingSession.update).toHaveBeenCalled();
+    const statusUpdate = db.sessionUpdates.find((u) => u.StatusID === 7);
+    expect(statusUpdate).toBeDefined();
+
+    // Admin notification sent
+    expect(db.notificationsCreated.length).toBeGreaterThan(0);
+    expect(db.notificationsCreated[0].UserID).toBe(99); // adminUser.UserID
+    expect(db.notificationsCreated[0].SessionID).toBe(1);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// POST /teacher/sessions/:id/no-show
+// ---------------------------------------------------------------------------
+
+describe('POST /teacher/sessions/:id/no-show (BR-16)', () => {
+  const validBody = { studentAccountId: 10, remarks: 'Aluno não apareceu nem avisou.' };
+
+  test('returns 401 when unauthenticated', async () => {
+    const { app } = createContext();
+    const res = await request(app).post('/teacher/sessions/1/no-show').send(validBody);
+    expect(res.status).toBe(401);
+  });
+
+  test('returns 403 for student role', async () => {
+    const { app, studentUser } = createContext();
+    const agent = request.agent(app);
+    await loginAs(agent, studentUser);
+
+    const res = await agent.post('/teacher/sessions/1/no-show').send(validBody);
+    expect(res.status).toBe(403);
+  });
+
+  test('returns 400 when studentAccountId is missing', async () => {
+    const { app, teacherUser, db } = createContext();
+    db.sessionRow = buildSession({ sessionId: 1, endTime: PAST_TIME });
+    const agent = request.agent(app);
+    await loginAs(agent, teacherUser);
+
+    const res = await agent.post('/teacher/sessions/1/no-show').send({ remarks: 'x' });
+    expect(res.status).toBe(400);
+    expect(res.body.error).toMatch(/studentAccountId/i);
+  });
+
+  test('returns 400 when remarks are empty — BR-16 requires justification', async () => {
+    const { app, teacherUser, db } = createContext();
+    db.sessionRow = buildSession({ sessionId: 1, endTime: PAST_TIME });
+    const agent = request.agent(app);
+    await loginAs(agent, teacherUser);
+
+    const res = await agent.post('/teacher/sessions/1/no-show').send({ studentAccountId: 10, remarks: '   ' });
+    expect(res.status).toBe(400);
+    expect(res.body.error).toMatch(/remarks/i);
+  });
+
+  test('returns 404 when session not found', async () => {
+    const { app, teacherUser, db } = createContext();
+    db.sessionRow = null;
+    const agent = request.agent(app);
+    await loginAs(agent, teacherUser);
+
+    const res = await agent.post('/teacher/sessions/99/no-show').send(validBody);
+    expect(res.status).toBe(404);
+  });
+
+  test('returns 409 when session has not ended yet', async () => {
+    const { app, teacherUser, db } = createContext();
+    db.sessionRow = buildSession({
+      sessionId: 1,
+      endTime: FUTURE_TIME,
+      students: [buildEnrollment({ studentAccountId: 10 })],
+    });
+    const agent = request.agent(app);
+    await loginAs(agent, teacherUser);
+
+    const res = await agent.post('/teacher/sessions/1/no-show').send(validBody);
+    expect(res.status).toBe(409);
+    expect(res.body.error).toMatch(/before session end/i);
+  });
+
+  test('returns 404 when student not enrolled', async () => {
+    const { app, teacherUser, db } = createContext();
+    db.sessionRow = buildSession({ sessionId: 1, endTime: PAST_TIME, students: [] });
+    const agent = request.agent(app);
+    await loginAs(agent, teacherUser);
+
+    const res = await agent.post('/teacher/sessions/1/no-show').send(validBody);
+    expect(res.status).toBe(404);
+    expect(res.body.error).toMatch(/enrollment not found/i);
+  });
+
+  test('returns 409 when no-show already registered', async () => {
+    const { app, teacherUser, db } = createContext();
+    db.sessionRow = buildSession({
+      sessionId: 1,
+      endTime: PAST_TIME,
+      students: [buildEnrollment({ studentAccountId: 10, attendanceStatus: 'NO_SHOW' })],
+    });
+    const agent = request.agent(app);
+    await loginAs(agent, teacherUser);
+
+    const res = await agent.post('/teacher/sessions/1/no-show').send(validBody);
+    expect(res.status).toBe(409);
+    expect(res.body.error).toMatch(/already registered/i);
+  });
+
+  test('registers no-show, updates attendance, notifies student and admins, applies BR-16 penalty', async () => {
+    const { app, teacherUser, db, prismaMock } = createContext();
+    db.sessionRow = buildSession({
+      sessionId: 1,
+      endTime: PAST_TIME,
+      students: [buildEnrollment({ studentAccountId: 10, userId: 20, attendanceStatus: 'Pending' })],
+    });
+
+    const agent = request.agent(app);
+    await loginAs(agent, teacherUser);
+
+    const res = await agent.post('/teacher/sessions/1/no-show').send(validBody);
+    expect(res.status).toBe(201);
+    expect(res.body.sessionId).toBe(1);
+    expect(res.body.studentAccountId).toBe(10);
+    expect(res.body.attendanceStatus).toBe('NO_SHOW');
+
+    // Attendance updated to NO_SHOW (AttendanceStatusID 3)
+    expect(prismaMock.sessionStudent.update).toHaveBeenCalled();
+    expect(db.attendanceUpdate).toMatchObject({ AttendanceStatusID: 3 });
+
+    // Session status updated
+    expect(db.sessionUpdates.length).toBeGreaterThan(0);
+
+    // Notification to student (userId 20)
+    const studentNotif = db.notificationsCreated.find((n) => n.UserID === 20);
+    expect(studentNotif).toBeDefined();
+    expect(studentNotif.SessionID).toBe(1);
+
+    // Notification to admin (userId 99)
+    const adminNotif = db.notificationsCreated.find((n) => n.UserID === 99);
+    expect(adminNotif).toBeDefined();
+
+    // BR-16 penalty triggered (pricingService called because financialEntry.findFirst returned null)
+    expect(db.noShowPenaltyApplied).toBe(true);
+  });
+
+  test('skips penalty if financial entry already exists', async () => {
+    const { app, teacherUser, db } = createContext();
+    db.sessionRow = buildSession({
+      sessionId: 1,
+      endTime: PAST_TIME,
+      students: [buildEnrollment({ studentAccountId: 10, attendanceStatus: 'Pending' })],
+    });
+    db.existingPenalty = { EntryID: 42 }; // already has a penalty
+
+    const agent = request.agent(app);
+    await loginAs(agent, teacherUser);
+
+    const res = await agent.post('/teacher/sessions/1/no-show').send(validBody);
+    expect(res.status).toBe(201);
+    expect(res.body.penaltyEntryId).toBe(42);
+    expect(db.noShowPenaltyApplied).toBe(false); // not called again
+  });
+});

--- a/server/tests/setupEnv.js
+++ b/server/tests/setupEnv.js
@@ -2,6 +2,7 @@ process.env.NODE_ENV = 'test';
 process.env.CLIENT_URL = 'http://localhost:5173';
 process.env.CORS_ORIGINS = 'http://localhost:5173';
 process.env.CORS_ALLOW_NO_ORIGIN = 'true';
+process.env.CSRF_ALLOW_NO_ORIGIN = 'true';
 process.env.SESSION_SECRET = 'jest-test-secret';
 process.env.DATABASE_URL =
   'sqlserver://localhost;database=gestArtes_test;user=test;password=test;encrypt=true;trustServerCertificate=true;';

--- a/src/controllers/teacher.controller.js
+++ b/src/controllers/teacher.controller.js
@@ -1,8 +1,16 @@
 const prisma = require('../config/prisma');
+const { createPricingService } = require('../services/pricing.service');
 
 const DEFAULT_NOTIFICATION_TYPE_ID = 1;
 const TEACHER_APPROVED_STATUS = 'TEACHER_APPROVED';
 const TEACHER_REJECTED_STATUS = 'TEACHER_REJECTED';
+const FINALIZATION_VALIDATION_PENDING_STATUS = 'FINALIZATION_VALIDATION_PENDING';
+const TEACHER_CONFIRMATION_STEP = 'TeacherConfirmation';
+const NO_SHOW_STATUS = 'NO_SHOW';
+const NO_SHOW_ATTENDANCE_STATUS = 'NO_SHOW';
+const NO_SHOW_STEP = 'NoShowRecorded';
+
+const pricingService = createPricingService(prisma);
 
 function toInteger(value) {
   if (typeof value === 'bigint') {
@@ -17,6 +25,13 @@ function normalizeString(value) {
   return String(value || '')
     .trim()
     .toLowerCase();
+}
+
+function normalizeKey(value) {
+  return String(value || '')
+    .trim()
+    .toLowerCase()
+    .replace(/[^a-z0-9]/g, '');
 }
 
 function getAuthenticatedTeacherUserId(req, res) {
@@ -109,6 +124,145 @@ function truncateNotificationMessage(message) {
   }
 
   return `${trimmed.slice(0, 252)}...`;
+}
+
+function isTerminalSessionStatus(statusName) {
+  const normalized = normalizeKey(statusName);
+
+  return normalized.includes('cancel') || normalized.includes('finalized');
+}
+
+function isNoShowSessionStatus(statusName) {
+  return normalizeKey(statusName) === normalizeKey(NO_SHOW_STATUS);
+}
+
+function hasTeacherConfirmationByUser(validations, teacherUserId) {
+  return validations.some((validation) => {
+    if (validation.ValidatedByUserID !== teacherUserId) {
+      return false;
+    }
+
+    const stepName = normalizeKey(validation.ValidationStep?.StepName);
+    return stepName.includes('teacher') && stepName.includes('confirm');
+  });
+}
+
+function appendNoShowRemark(previousNotes, remark) {
+  const prefix = 'NO_SHOW: ';
+  const incoming = `${prefix}${String(remark || '').trim()}`;
+  const existing = String(previousNotes || '').trim();
+
+  if (!existing) {
+    return incoming.slice(0, 255);
+  }
+
+  return `${existing} | ${incoming}`.slice(0, 255);
+}
+
+async function getOrCreateValidationStep(db, stepName, keywords) {
+  const allSteps = await db.validationStep.findMany({
+    select: { StepID: true, StepName: true },
+  });
+
+  const found = allSteps.find((step) => {
+    const normalized = normalizeKey(step.StepName);
+    return keywords.every((keyword) => normalized.includes(normalizeKey(keyword)));
+  });
+
+  if (found) {
+    return found.StepID;
+  }
+
+  const created = await db.validationStep.create({
+    data: { StepName: stepName },
+    select: { StepID: true },
+  });
+
+  return created.StepID;
+}
+
+async function resolveOrCreateSessionStatusId(db, desiredStatusName, aliases = []) {
+  const statuses = await db.sessionStatus.findMany({
+    select: { StatusID: true, StatusName: true },
+  });
+
+  const desiredNormalized = normalizeKey(desiredStatusName);
+  const aliasSet = new Set([desiredNormalized, ...aliases.map((alias) => normalizeKey(alias))]);
+
+  const found = statuses.find((status) => aliasSet.has(normalizeKey(status.StatusName)));
+
+  if (found) {
+    return found.StatusID;
+  }
+
+  const created = await db.sessionStatus.create({
+    data: { StatusName: desiredStatusName },
+    select: { StatusID: true },
+  });
+
+  return created.StatusID;
+}
+
+async function resolveOrCreateAttendanceStatusId(db, desiredStatusName, aliases = []) {
+  const statuses = await db.attendanceStatus.findMany({
+    select: { AttendanceStatusID: true, StatusName: true },
+  });
+
+  const desiredNormalized = normalizeKey(desiredStatusName);
+  const aliasSet = new Set([desiredNormalized, ...aliases.map((alias) => normalizeKey(alias))]);
+
+  const found = statuses.find((status) => aliasSet.has(normalizeKey(status.StatusName)));
+
+  if (found) {
+    return found.AttendanceStatusID;
+  }
+
+  const created = await db.attendanceStatus.create({
+    data: { StatusName: desiredStatusName },
+    select: { AttendanceStatusID: true },
+  });
+
+  return created.AttendanceStatusID;
+}
+
+async function listAdminUserIds(db) {
+  const rows = await db.userRole.findMany({
+    where: {
+      Role: {
+        RoleName: {
+          equals: 'admin',
+          mode: 'insensitive',
+        },
+      },
+      User: {
+        IsActive: true,
+      },
+    },
+    select: { UserID: true },
+  });
+
+  return [...new Set(rows.map((row) => row.UserID).filter((userId) => Number.isInteger(userId) && userId > 0))];
+}
+
+async function createAdminNotifications(db, { sessionId, title, message }) {
+  const adminUserIds = await listAdminUserIds(db);
+
+  if (adminUserIds.length === 0) {
+    return;
+  }
+
+  const now = new Date();
+  const payload = adminUserIds.map((userId) => ({
+    UserID: userId,
+    Message: truncateNotificationMessage(message),
+    TypeID: DEFAULT_NOTIFICATION_TYPE_ID,
+    IsRead: false,
+    CreatedAt: now,
+    Title: buildNotificationTitle(title || message),
+    SessionID: sessionId,
+  }));
+
+  await db.notification.createMany({ data: payload });
 }
 
 function toUTCDateString(date) {
@@ -518,12 +672,452 @@ async function getTodaySchedule(req, res, next) {
   }
 }
 
+async function getPendingSessions(req, res, next) {
+  try {
+    const teacherUserId = getAuthenticatedTeacherUserId(req, res);
+
+    if (!teacherUserId) {
+      return;
+    }
+
+    const now = new Date();
+
+    const sessions = await prisma.coachingSession.findMany({
+      where: {
+        EndTime: {
+          lte: now,
+        },
+        SessionTeacher: {
+          some: {
+            TeacherID: teacherUserId,
+          },
+        },
+      },
+      include: {
+        SessionStatus: {
+          select: {
+            StatusID: true,
+            StatusName: true,
+          },
+        },
+        Studio: {
+          select: {
+            StudioName: true,
+          },
+        },
+        Modality: {
+          select: {
+            ModalityName: true,
+          },
+        },
+        SessionValidation: {
+          include: {
+            ValidationStep: {
+              select: {
+                StepName: true,
+              },
+            },
+          },
+        },
+        SessionStudent: {
+          include: {
+            AttendanceStatus: {
+              select: {
+                StatusName: true,
+              },
+            },
+            StudentAccount: {
+              include: {
+                User: {
+                  select: {
+                    UserID: true,
+                    FirstName: true,
+                    LastName: true,
+                    Email: true,
+                  },
+                },
+              },
+            },
+          },
+        },
+      },
+      orderBy: [
+        { EndTime: 'asc' },
+        { SessionID: 'asc' },
+      ],
+    });
+
+    const pendingSessions = sessions
+      .filter((session) => {
+        const statusName = session.SessionStatus?.StatusName;
+        // Exclude cancelled/finalized; keep NO_SHOW sessions so teacher can still mark other enrolled students
+        return !isTerminalSessionStatus(statusName);
+      })
+      .map((session) => {
+        const teacherConfirmed = hasTeacherConfirmationByUser(session.SessionValidation, teacherUserId);
+
+        return {
+          sessionId: session.SessionID,
+          startTime: session.StartTime,
+          endTime: session.EndTime,
+          statusId: session.SessionStatus?.StatusID ?? null,
+          statusName: session.SessionStatus?.StatusName ?? null,
+          studioName: session.Studio?.StudioName ?? null,
+          modalityName: session.Modality?.ModalityName ?? null,
+          teacherConfirmed,
+          canConfirmCompletion: !teacherConfirmed,
+          students: session.SessionStudent.map((student) => ({
+            studentAccountId: student.StudentAccountID,
+            studentUserId: student.StudentAccount?.User?.UserID ?? null,
+            studentName: [
+              student.StudentAccount?.User?.FirstName,
+              student.StudentAccount?.User?.LastName,
+            ]
+              .filter(Boolean)
+              .join(' ')
+              .trim(),
+            studentEmail: student.StudentAccount?.User?.Email ?? null,
+            attendanceStatus: student.AttendanceStatus?.StatusName ?? null,
+            canRegisterNoShow: normalizeKey(student.AttendanceStatus?.StatusName) !== normalizeKey(NO_SHOW_ATTENDANCE_STATUS),
+          })),
+        };
+      });
+
+    return res.json({
+      summary: {
+        pendingCount: pendingSessions.length,
+      },
+      sessions: pendingSessions,
+    });
+  } catch (error) {
+    return next(error);
+  }
+}
+
+async function confirmCompletion(req, res, next) {
+  try {
+    const teacherUserId = getAuthenticatedTeacherUserId(req, res);
+
+    if (!teacherUserId) {
+      return;
+    }
+
+    const sessionId = Number(req.params?.id);
+
+    if (!Number.isInteger(sessionId) || sessionId <= 0) {
+      return res.status(400).json({ error: 'Invalid session id' });
+    }
+
+    const session = await prisma.coachingSession.findFirst({
+      where: {
+        SessionID: sessionId,
+        SessionTeacher: {
+          some: {
+            TeacherID: teacherUserId,
+          },
+        },
+      },
+      include: {
+        SessionStatus: {
+          select: {
+            StatusName: true,
+          },
+        },
+        SessionValidation: {
+          include: {
+            ValidationStep: {
+              select: {
+                StepName: true,
+              },
+            },
+          },
+        },
+      },
+    });
+
+    if (!session) {
+      return res.status(404).json({ error: 'Session not found' });
+    }
+
+    if (new Date(session.EndTime) > new Date()) {
+      return res.status(409).json({ error: 'Session has not ended yet' });
+    }
+
+    const sessionStatusName = session.SessionStatus?.StatusName;
+    if (isTerminalSessionStatus(sessionStatusName) || isNoShowSessionStatus(sessionStatusName)) {
+      return res.status(409).json({ error: 'Session is not eligible for completion confirmation' });
+    }
+
+    if (hasTeacherConfirmationByUser(session.SessionValidation, teacherUserId)) {
+      return res.status(409).json({ error: 'Session was already confirmed by this teacher' });
+    }
+
+    const result = await prisma.$transaction(async (tx) => {
+      const teacherStepId = await getOrCreateValidationStep(tx, TEACHER_CONFIRMATION_STEP, ['teacher', 'confirm']);
+      const finalizationPendingStatusId = await resolveOrCreateSessionStatusId(
+        tx,
+        FINALIZATION_VALIDATION_PENDING_STATUS,
+        ['finalization validation pending', 'finalizationpending', 'finalvalidationpending'],
+      );
+
+      const createdValidation = await tx.sessionValidation.create({
+        data: {
+          SessionID: sessionId,
+          ValidatedByUserID: teacherUserId,
+          ValidatedAt: new Date(),
+          ValidationStepID: teacherStepId,
+        },
+        select: {
+          ValidationID: true,
+          ValidatedAt: true,
+        },
+      });
+
+      const updatedSession = await tx.coachingSession.update({
+        where: {
+          SessionID: sessionId,
+        },
+        data: {
+          StatusID: finalizationPendingStatusId,
+          ValidationRequestedAt: new Date(),
+        },
+        include: {
+          SessionStatus: {
+            select: {
+              StatusName: true,
+            },
+          },
+        },
+      });
+
+      await createAdminNotifications(tx, {
+        sessionId,
+        title: 'Sessao pronta para validacao final',
+        message: `A sessao #${sessionId} foi confirmada pelo professor e aguarda validacao final da administracao.`,
+      });
+
+      return {
+        validationId: createdValidation.ValidationID,
+        validatedAt: createdValidation.ValidatedAt,
+        statusName: updatedSession.SessionStatus?.StatusName ?? FINALIZATION_VALIDATION_PENDING_STATUS,
+      };
+    });
+
+    return res.status(201).json({
+      sessionId,
+      validationId: result.validationId,
+      validatedAt: result.validatedAt,
+      status: result.statusName,
+    });
+  } catch (error) {
+    return next(error);
+  }
+}
+
+async function registerNoShow(req, res, next) {
+  try {
+    const teacherUserId = getAuthenticatedTeacherUserId(req, res);
+
+    if (!teacherUserId) {
+      return;
+    }
+
+    const sessionId = Number(req.params?.id);
+    const studentAccountId = Number(req.body?.studentAccountId);
+    const remarks = String(req.body?.remarks || '').trim();
+
+    if (!Number.isInteger(sessionId) || sessionId <= 0) {
+      return res.status(400).json({ error: 'Invalid session id' });
+    }
+
+    if (!Number.isInteger(studentAccountId) || studentAccountId <= 0) {
+      return res.status(400).json({ error: 'Invalid studentAccountId' });
+    }
+
+    if (!remarks) {
+      return res.status(400).json({ error: 'Remarks are required for no-show registration' });
+    }
+
+    const session = await prisma.coachingSession.findFirst({
+      where: {
+        SessionID: sessionId,
+        SessionTeacher: {
+          some: {
+            TeacherID: teacherUserId,
+          },
+        },
+      },
+      include: {
+        SessionStatus: {
+          select: {
+            StatusName: true,
+          },
+        },
+        SessionStudent: {
+          where: {
+            StudentAccountID: studentAccountId,
+          },
+          include: {
+            AttendanceStatus: {
+              select: {
+                StatusName: true,
+              },
+            },
+            StudentAccount: {
+              include: {
+                User: {
+                  select: {
+                    UserID: true,
+                    FirstName: true,
+                    LastName: true,
+                  },
+                },
+              },
+            },
+          },
+        },
+      },
+    });
+
+    if (!session) {
+      return res.status(404).json({ error: 'Session not found' });
+    }
+
+    if (new Date(session.EndTime) > new Date()) {
+      return res.status(409).json({ error: 'Cannot register no-show before session end' });
+    }
+
+    if (isTerminalSessionStatus(session.SessionStatus?.StatusName)) {
+      return res.status(409).json({ error: 'Session is not eligible for no-show registration' });
+    }
+    // Allow no-show registration even if the session is already in NO_SHOW — another student may still need to be marked
+
+    const enrollment = session.SessionStudent[0];
+
+    if (!enrollment) {
+      return res.status(404).json({ error: 'Session enrollment not found for this student' });
+    }
+
+    if (normalizeKey(enrollment.AttendanceStatus?.StatusName) === normalizeKey(NO_SHOW_ATTENDANCE_STATUS)) {
+      return res.status(409).json({ error: 'No-show already registered for this enrollment' });
+    }
+
+    const result = await prisma.$transaction(async (tx) => {
+      const noShowAttendanceStatusId = await resolveOrCreateAttendanceStatusId(
+        tx,
+        NO_SHOW_ATTENDANCE_STATUS,
+        ['no show', 'noshow'],
+      );
+
+      const noShowSessionStatusId = await resolveOrCreateSessionStatusId(
+        tx,
+        NO_SHOW_STATUS,
+        ['no show', 'noshow'],
+      );
+
+      const noShowStepId = await getOrCreateValidationStep(tx, NO_SHOW_STEP, ['no', 'show']);
+
+      await tx.sessionStudent.update({
+        where: {
+          SessionID_StudentAccountID: {
+            SessionID: sessionId,
+            StudentAccountID: studentAccountId,
+          },
+        },
+        data: {
+          AttendanceStatusID: noShowAttendanceStatusId,
+        },
+      });
+
+      await tx.coachingSession.update({
+        where: {
+          SessionID: sessionId,
+        },
+        data: {
+          StatusID: noShowSessionStatusId,
+          ReviewNotes: appendNoShowRemark(session.ReviewNotes, remarks),
+        },
+      });
+
+      await tx.sessionValidation.create({
+        data: {
+          SessionID: sessionId,
+          ValidatedByUserID: teacherUserId,
+          ValidatedAt: new Date(),
+          ValidationStepID: noShowStepId,
+        },
+      });
+
+      const existingPenalty = await tx.financialEntry.findFirst({
+        where: {
+          SessionID: sessionId,
+          FinancialEntryType: {
+            TypeName: 'no_show_fee',
+          },
+        },
+        select: {
+          EntryID: true,
+        },
+      });
+
+      const penaltyEntry = existingPenalty
+        ? existingPenalty
+        : await pricingService.applyNoShowPenalty(sessionId, teacherUserId, tx);
+
+      await createAdminNotifications(tx, {
+        sessionId,
+        title: 'No-show registado',
+        message: `Foi registado no-show na sessao #${sessionId}. A penalizacao BR-16 foi acionada.`,
+      });
+
+      if (enrollment.StudentAccount?.User?.UserID) {
+        const studentName = [
+          enrollment.StudentAccount?.User?.FirstName,
+          enrollment.StudentAccount?.User?.LastName,
+        ]
+          .filter(Boolean)
+          .join(' ')
+          .trim();
+
+        await tx.notification.create({
+          data: {
+            UserID: enrollment.StudentAccount.User.UserID,
+            Message: truncateNotificationMessage(
+              `Foi registado no-show na sessao #${sessionId}${studentName ? ` para ${studentName}` : ''}. Foi aplicada penalizacao conforme BR-16.`,
+            ),
+            TypeID: DEFAULT_NOTIFICATION_TYPE_ID,
+            IsRead: false,
+            CreatedAt: new Date(),
+            Title: buildNotificationTitle('No-show registado e penalizacao aplicada'),
+            SessionID: sessionId,
+          },
+        });
+      }
+
+      return {
+        sessionId,
+        studentAccountId,
+        attendanceStatus: NO_SHOW_ATTENDANCE_STATUS,
+        sessionStatus: NO_SHOW_STATUS,
+        penaltyEntryId: penaltyEntry.EntryID,
+      };
+    });
+
+    return res.status(201).json(result);
+  } catch (error) {
+    return next(error);
+  }
+}
+
 module.exports = {
   approveJoinRequest,
+  confirmCompletion,
   getAdmissionRequests,
   getPendingAdmissions,
+  getPendingSessions,
   getDashboard,
   getTodaySchedule,
+  registerNoShow,
   rejectJoinRequest,
   reviewAdmissionRequest,
 };

--- a/src/routes/coaching.routes.js
+++ b/src/routes/coaching.routes.js
@@ -42,4 +42,11 @@ router.patch(
   coachingController.confirmCompletion
 );
 
+router.patch(
+  '/sessions/:id/validate',
+  requireAuth,
+  requireRole(['STUDENT']),
+  coachingController.confirmCompletion
+);
+
 module.exports = router;

--- a/src/routes/teacher.routes.js
+++ b/src/routes/teacher.routes.js
@@ -14,6 +14,10 @@ router.get('/admissions/pending', ...teacherAccess, teacherController.getPending
 router.patch('/admissions/:joinRequestId/approve', ...teacherAccess, teacherController.approveJoinRequest);
 router.patch('/admissions/:joinRequestId/reject', ...teacherAccess, teacherController.rejectJoinRequest);
 
+router.get('/sessions/pending', ...teacherAccess, teacherController.getPendingSessions);
+router.patch('/sessions/:id/confirm-completion', ...teacherAccess, teacherController.confirmCompletion);
+router.post('/sessions/:id/no-show', ...teacherAccess, teacherController.registerNoShow);
+
 router.get('/admission-requests', ...teacherAccess, teacherController.getAdmissionRequests);
 router.get('/dashboard', ...teacherAccess, teacherController.getDashboard);
 router.get('/schedule/today', ...teacherAccess, teacherController.getTodaySchedule);

--- a/src/services/pricing.service.js
+++ b/src/services/pricing.service.js
@@ -57,8 +57,8 @@ function createPricingService(prismaClient) {
     });
   }
 
-  async function applyNoShowPenalty(sessionId, userId) {
-    const { entry, finalPrice } = await prismaClient.$transaction(async (tx) => {
+  async function applyNoShowPenalty(sessionId, userId, client = prismaClient) {
+    const run = async (tx) => {
       const finalPrice = await calculateFinalPrice(sessionId, tx);
 
       const entryType = await tx.financialEntryType.findUnique({
@@ -80,7 +80,11 @@ function createPricingService(prismaClient) {
       });
 
       return { entry, finalPrice };
-    });
+    };
+
+    const { entry, finalPrice } = client === prismaClient
+      ? await prismaClient.$transaction(async (tx) => run(tx))
+      : await run(client);
 
     logAudit({
       userId,


### PR DESCRIPTION
This pull request introduces new endpoints for managing coaching session completion and no-show scenarios, as well as refactors part of the pricing service to improve flexibility in handling database transactions. The main focus is on expanding teacher and student capabilities for session management and making the pricing service more adaptable for different database contexts.

**Session Management Endpoints:**

* Added `PATCH /sessions/:id/validate` endpoint for students to confirm session completion, protected by authentication and role checks.
* Added teacher endpoints: `GET /sessions/pending` to list pending sessions, `PATCH /sessions/:id/confirm-completion` to confirm session completion, and `POST /sessions/:id/no-show` to register student no-shows. All are protected by teacher access middleware.

**Pricing Service Refactor:**

* Refactored `applyNoShowPenalty` in `pricing.service.js` to accept an optional database client, allowing for greater flexibility in transaction management and easier testing. [[1]](diffhunk://#diff-6d5941744ce39612e6eb1976a8e16d1c28413c407777c13a9705538a805aa145L60-R61) [[2]](diffhunk://#diff-6d5941744ce39612e6eb1976a8e16d1c28413c407777c13a9705538a805aa145L83-R87)