### PR TITLE
feat(inventory): add inventory search and filters

### DIFF
--- a/src/middlewares/schemas/inventory.schema.js
+++ b/src/middlewares/schemas/inventory.schema.js
@@ -1,5 +1,7 @@
 const { body, param, query } = require('express-validator');
 
+const inventoryStatusValues = ['AVAILABLE', 'RENTED', 'RESERVED', 'ALL'];
+
 function isValidPhotoUrl(value) {
   if (value === undefined || value === null || value === '') {
     return true;
@@ -81,6 +83,16 @@ const listInventoryItemsQuerySchema = [
     .trim()
     .isLength({ min: 1, max: 50 }).withMessage('Categoria inválida')
     .escape(),
+  query('status')
+    .optional()
+    .trim()
+    .customSanitizer((value) => String(value).trim().toUpperCase())
+    .isIn(inventoryStatusValues).withMessage('Estado de inventário inválido'),
+  query('availability')
+    .optional()
+    .trim()
+    .customSanitizer((value) => String(value).trim().toUpperCase())
+    .isIn(inventoryStatusValues).withMessage('Estado de inventário inválido'),
   query('onlyAvailable')
     .optional()
     .isBoolean().withMessage('Filtro de disponibilidade inválido')
@@ -94,6 +106,26 @@ const listInventoryItemsQuerySchema = [
     .trim()
     .isLength({ min: 1, max: 100 }).withMessage('Pesquisa inválida')
     .escape(),
+  query('price')
+    .optional()
+    .isFloat({ min: 0 }).withMessage('Preço inválido')
+    .toFloat(),
+  query('minPrice')
+    .optional()
+    .isFloat({ min: 0 }).withMessage('Preço mínimo inválido')
+    .toFloat(),
+  query('maxPrice')
+    .optional()
+    .isFloat({ min: 0 }).withMessage('Preço máximo inválido')
+    .toFloat(),
+  query('priceMin')
+    .optional()
+    .isFloat({ min: 0 }).withMessage('Preço mínimo inválido')
+    .toFloat(),
+  query('priceMax')
+    .optional()
+    .isFloat({ min: 0 }).withMessage('Preço máximo inválido')
+    .toFloat(),
   query('availableOnly')
     .optional()
     .isBoolean().withMessage('Filtro de disponibilidade inválido')

--- a/src/services/inventory.service.js
+++ b/src/services/inventory.service.js
@@ -22,6 +22,42 @@ function normalizeString(value) {
     .toLowerCase();
 }
 
+function normalizeStatusFilter(value) {
+  const normalized = normalizeString(value);
+
+  if (!normalized) {
+    return null;
+  }
+
+  if (normalized === 'all') {
+    return null;
+  }
+
+  if (['available', 'available-only', 'available_only', 'free', 'livre'].includes(normalized)) {
+    return 'available';
+  }
+
+  if (['rented', 'reserved', 'unavailable', 'occupied', 'alugado'].includes(normalized)) {
+    return 'rented';
+  }
+
+  return null;
+}
+
+function parsePositiveMoney(value) {
+  if (value === undefined || value === null || value === '') {
+    return null;
+  }
+
+  const numeric = Number(value);
+
+  if (!Number.isFinite(numeric) || numeric < 0) {
+    throw createHttpError(400, 'Preço inválido');
+  }
+
+  return numeric;
+}
+
 function isSchoolOwnedItem(item) {
   return item?.IsSchoolOwned !== false;
 }
@@ -60,6 +96,41 @@ function buildSearchFilter(rawSearch) {
         },
       },
     ],
+  };
+}
+
+function buildInventoryStatusFilter(filters = {}) {
+  const explicitStatus = normalizeStatusFilter(filters.status || filters.availability);
+
+  if (explicitStatus) {
+    return explicitStatus;
+  }
+
+  if (
+    filters.availableOnly === true
+    || normalizeString(filters.availableOnly) === 'true'
+    || filters.onlyAvailable === true
+    || normalizeString(filters.onlyAvailable) === 'true'
+  ) {
+    return 'available';
+  }
+
+  return null;
+}
+
+function buildInventoryPriceFilter(filters = {}) {
+  const exactPrice = parsePositiveMoney(filters.price);
+  const minPrice = parsePositiveMoney(filters.priceMin ?? filters.minPrice);
+  const maxPrice = parsePositiveMoney(filters.priceMax ?? filters.maxPrice);
+
+  if (exactPrice === null && minPrice === null && maxPrice === null) {
+    return null;
+  }
+
+  return {
+    exactPrice,
+    minPrice,
+    maxPrice,
   };
 }
 
@@ -216,13 +287,38 @@ function buildInventoryWhere(filters = {}) {
   return where;
 }
 
-function shouldOnlyReturnAvailable(filters = {}) {
-  return (
-    filters.availableOnly === true
-    || normalizeString(filters.availableOnly) === 'true'
-    || filters.onlyAvailable === true
-    || normalizeString(filters.onlyAvailable) === 'true'
-  );
+function matchesInventoryStatusFilter(item, statusFilter) {
+  if (!statusFilter) {
+    return true;
+  }
+
+  if (statusFilter === 'available') {
+    return item.isAvailable;
+  }
+
+  return !item.isAvailable;
+}
+
+function matchesInventoryPriceFilter(item, priceFilter) {
+  if (!priceFilter) {
+    return true;
+  }
+
+  const symbolicFee = Number(item.symbolicFee ?? 0);
+
+  if (priceFilter.exactPrice !== null && symbolicFee !== priceFilter.exactPrice) {
+    return false;
+  }
+
+  if (priceFilter.minPrice !== null && symbolicFee < priceFilter.minPrice) {
+    return false;
+  }
+
+  if (priceFilter.maxPrice !== null && symbolicFee > priceFilter.maxPrice) {
+    return false;
+  }
+
+  return true;
 }
 
 async function loadReservedQuantities(db, itemIds) {
@@ -263,17 +359,18 @@ async function listItems(filters = {}) {
 
   const itemIds = items.map((item) => item.InventoryItemID);
   const activeRentalsByItem = await loadReservedQuantities(prisma, itemIds);
+  const statusFilter = buildInventoryStatusFilter(filters);
+  const priceFilter = buildInventoryPriceFilter(filters);
 
   const result = items.map((item) => {
     const activeRentalsCount = activeRentalsByItem.get(item.InventoryItemID) || 0;
     return serializeItem(item, activeRentalsCount);
   });
 
-  if (shouldOnlyReturnAvailable(filters)) {
-    return result.filter((item) => item.isAvailable);
-  }
-
-  return result;
+  return result.filter((item) => (
+    matchesInventoryStatusFilter(item, statusFilter)
+    && matchesInventoryPriceFilter(item, priceFilter)
+  ));
 }
 
 async function getItemById(itemId) {

--- a/test/integration/inventory.integration.test.js
+++ b/test/integration/inventory.integration.test.js
@@ -445,6 +445,39 @@ test('teacher can list and filter inventory items', async () => {
   assert.equal(body.items[0].availableQuantity, 1);
 });
 
+test('teacher can filter inventory items by status', async () => {
+  const response = await request('/inventory/items?status=AVAILABLE', {
+    headers: {
+      'x-test-user-id': '210',
+      'x-test-role': 'teacher',
+    },
+  });
+
+  assert.equal(response.status, 200);
+
+  const body = await response.json();
+  assert.ok(Array.isArray(body.items));
+  assert.equal(body.items.length, 1);
+  assert.equal(body.items[0].itemId, 1);
+});
+
+test('teacher can filter inventory items by category and price range', async () => {
+  const response = await request('/inventory/items?availability=RENTED&category=Cenario&minPrice=8&maxPrice=10', {
+    headers: {
+      'x-test-user-id': '210',
+      'x-test-role': 'teacher',
+    },
+  });
+
+  assert.equal(response.status, 200);
+
+  const body = await response.json();
+  assert.ok(Array.isArray(body.items));
+  assert.equal(body.items.length, 1);
+  assert.equal(body.items[0].itemId, 2);
+  assert.equal(body.items[0].symbolicFee, 9);
+});
+
 test('teacher inventory alias reuses the shared inventory router', async () => {
   const response = await request('/teacher/inventory/items?availableOnly=true', {
     headers: {


### PR DESCRIPTION
This pull request enhances the inventory item filtering capabilities by adding support for status and price range filters, improving the flexibility and accuracy of inventory queries. It introduces new query parameters, refactors filter logic for maintainability, and adds comprehensive tests to ensure correct behavior.

**Inventory filtering improvements:**

* Added support for filtering inventory items by `status` and `availability` query parameters, with validation for allowed values (`AVAILABLE`, `RENTED`, `RESERVED`, `ALL`). [[1]](diffhunk://#diff-d42c894bff714e8c8f10ec0f2d17b4d8336c6304b3995cf896e30fbb61c1b6d7R3-R4) [[2]](diffhunk://#diff-d42c894bff714e8c8f10ec0f2d17b4d8336c6304b3995cf896e30fbb61c1b6d7R86-R95)
* Introduced price-based filtering with new query parameters: `price`, `minPrice`, `maxPrice`, `priceMin`, and `priceMax`, including validation and type conversion.

**Filter logic refactoring:**

* Added utility functions (`normalizeStatusFilter`, `buildInventoryStatusFilter`, `matchesInventoryStatusFilter`, `buildInventoryPriceFilter`, `matchesInventoryPriceFilter`, and `parsePositiveMoney`) to centralize and clarify status and price filtering logic. [[1]](diffhunk://#diff-96bbc142f6f5f900782103d692bd587cbffa9ac72ef8afb56e514a457f4d8336R25-R60) [[2]](diffhunk://#diff-96bbc142f6f5f900782103d692bd587cbffa9ac72ef8afb56e514a457f4d8336R102-R136) [[3]](diffhunk://#diff-96bbc142f6f5f900782103d692bd587cbffa9ac72ef8afb56e514a457f4d8336L219-R321)
* Updated the main `listItems` service to use the new status and price filtering logic, replacing the previous availability-only filter.

**Testing:**

* Added integration tests to verify filtering by status and by category with price range, ensuring the new filters work as intended.